### PR TITLE
rewrote png_save_uint_32 and png_save_int_32 for portability and to eliminate undefined behaviors

### DIFF
--- a/png.c
+++ b/png.c
@@ -680,10 +680,7 @@ png_init_io(png_structrp png_ptr, png_FILE_p fp)
 void PNGAPI
 png_save_int_32(png_bytep buf, png_int_32 i)
 {
-   buf[0] = (png_byte)((i >> 24) & 0xff);
-   buf[1] = (png_byte)((i >> 16) & 0xff);
-   buf[2] = (png_byte)((i >> 8) & 0xff);
-   buf[3] = (png_byte)(i & 0xff);
+   png_save_uint_32(buf, (png_uint_32)i);
 }
 #  endif
 

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -23,10 +23,13 @@
 void PNGAPI
 png_save_uint_32(png_bytep buf, png_uint_32 i)
 {
-   buf[0] = (png_byte)(i >> 24);
-   buf[1] = (png_byte)(i >> 16);
-   buf[2] = (png_byte)(i >> 8);
-   buf[3] = (png_byte)(i     );
+  buf[3] = i % 256;
+  i = i / 256;
+  buf[2] = i % 256;
+  i = i / 256;
+  buf[1] = i % 256;
+  i = i / 256;
+  buf[0] = i % 256;
 }
 
 /* Place a 16-bit number into a buffer in PNG byte order.
@@ -36,8 +39,8 @@ png_save_uint_32(png_bytep buf, png_uint_32 i)
 void PNGAPI
 png_save_uint_16(png_bytep buf, unsigned int i)
 {
-   buf[0] = (png_byte)(i >> 8);
-   buf[1] = (png_byte)(i     );
+  buf[0] = (png_byte)((i >> 8) & 0xff);
+   buf[1] = (png_byte)(i & 0xff);
 }
 #endif
 


### PR DESCRIPTION
rewrote png_save_uint_32 function to be portable across difference sizes of int without undefined behavior

rewrote png_save_int_32 to use png_save_uint32

tested both functions for all integer values.