### PR TITLE
Coverity related changes

### DIFF
--- a/pngerror.c
+++ b/pngerror.c
@@ -1162,6 +1162,34 @@ PNG_FUNCTION(void,png_affirm,(png_const_structrp png_ptr,
 #  endif /* AFFIRM_ERROR */
 }
 
+#if !PNG_RELEASE_BUILD
+void /* PRIVATE */
+png_handled_affirm(png_const_structrp png_ptr, png_const_charp message,
+   unsigned int position)
+{
+#  if PNG_RELEASE_BUILD
+      /* testing in RC: we want to return control to the caller, so do not
+       * use png_affirm.
+       */
+      char   buffer[512];
+
+      affirm_text(buffer, message, position);
+
+#     ifdef PNG_CONSOLE_IO_SUPPORTED
+         fprintf(stderr, "%s\n", buffer);
+#     elif defined PNG_WARNINGS_SUPPORTED
+         if (png_ptr != NULL && png_ptr->warning_fn != NULL)
+            png_ptr->warning_fn(png_constcast(png_structrp, png_ptr), buffer);
+         /* else no way to output the text */
+#     else
+         PNG_UNUSED(png_ptr)
+#     endif
+#  else
+      png_affirm(png_ptr, message, position);
+#  endif
+}
+#endif /* !RELEASE_BUILD */
+
 #ifdef PNG_RANGE_CHECK_SUPPORTED
 /* The character/byte checking APIs. These do their own calls to png_affirm
  * because the caller provides the position.
@@ -1209,32 +1237,5 @@ png_u16_affirm(png_const_structrp png_ptr, unsigned int position, int b)
    png_affirm(png_ptr, param_deb("PNG 16-bit range") position);
 }
 #endif /* INT_MAX >= 65535 */
-
-void /* PRIVATE */
-png_handled_affirm(png_const_structrp png_ptr, png_const_charp message,
-   unsigned int position)
-{
-#  if PNG_RELEASE_BUILD
-      /* testing in RC: we want to return control to the caller, so do not
-       * use png_affirm.
-       */
-      char   buffer[512];
-
-      affirm_text(buffer, message, position);
-
-#     ifdef PNG_CONSOLE_IO_SUPPORTED
-         fprintf(stderr, "%s\n", buffer);
-#     elif defined PNG_WARNINGS_SUPPORTED
-         if (png_ptr != NULL && png_ptr->warning_fn != NULL)
-            png_ptr->warning_fn(png_constcast(png_structrp, png_ptr), buffer);
-         /* else no way to output the text */
-#     else
-         PNG_UNUSED(png_ptr)
-#     endif
-#  else
-      png_affirm(png_ptr, message, position);
-#  endif
-}
-
 #endif /* RANGE_CHECK */
 #endif /* READ || WRITE */

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -1506,7 +1506,7 @@ png_gamma_significant(png_const_structrp png_ptr, png_fixed_point gamma_val,
    };
 
    /* Handle out of range values in release by doing the gamma correction: */
-   debug(sbits > 0U && sbits <= 16U);
+   debug_handled(sbits > 0U && sbits <= 16U);
    if (sbits == 0U || sbits > 16U)
       return 1;
 

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -3329,8 +3329,11 @@ png_combine_row(png_const_structrp png_ptr, png_bytep dp, int display)
                switch (pixel_depth)
                {
                   case 1: spixel_rep &=  1; spixel_rep |= spixel_rep << 1;
+                          /*FALL THROUGH*/
                   case 2: spixel_rep &=  3; spixel_rep |= spixel_rep << 2;
+                          /*FALL THROUGH*/
                   case 4: spixel_rep &= 15; spixel_rep |= spixel_rep << 4;
+                          /*FALL THROUGH*/
                   default:
                      break;
                }
@@ -3420,8 +3423,11 @@ png_combine_row(png_const_structrp png_ptr, png_bytep dp, int display)
                switch (pixel_depth)
                {
                   case 1: spixel_rep &=  1; spixel_rep |= spixel_rep << 1;
+                          /*FALL THROUGH*/
                   case 2: spixel_rep &=  3; spixel_rep |= spixel_rep << 2;
+                          /*FALL THROUGH*/
                   case 4: spixel_rep &= 15; spixel_rep |= spixel_rep << 4;
+                          /*FALL THROUGH*/
                   default:
                      break;
                }
@@ -4023,7 +4029,8 @@ png_read_process_IDAT(png_structrp png_ptr)
           * once at the start:
           */
          png_ptr->zstream.next_out = png_ptr->row_buffer;
-         state = need_row_bytes;
+         /* state = need_row_bytes; [not used below] */
+         /* FALL THROUGH */
 
       case need_row_bytes:
          {
@@ -4140,7 +4147,7 @@ png_read_process_IDAT(png_structrp png_ptr)
             }
          } /* need_row_bytes */
 
-         state = need_filter_byte;
+         state = need_filter_byte; /* as opposed to 'start_of_pass' */
          /* FALL THROUGH */
 
       case need_filter_byte: /* for the next row */
@@ -4376,11 +4383,11 @@ png_read_finish_IDAT(png_structrp png_ptr)
    if (!png_ptr->zstream_ended)
    {
       int end_of_IDAT = png_ptr->zstream.avail_in == 0;
-      png_byte b;
-      png_alloc_size_t cb = png_inflate_IDAT(png_ptr, 2/*finish*/, &b, 1);
+      png_byte b[1];
+      png_alloc_size_t cb = png_inflate_IDAT(png_ptr, 2/*finish*/, b, 1);
 
       debug(png_ptr->zstream.avail_out == 1-cb &&
-            png_ptr->zstream.next_out == cb + &b);
+            png_ptr->zstream.next_out == cb + b);
 
       /* As above, for safety do this: */
       png_ptr->zstream.next_out = NULL;
@@ -4426,7 +4433,7 @@ png_read_finish_IDAT(png_structrp png_ptr)
       /* In fact we expect this to always succeed, so it is a good idea to
        * catch it in pre-release builds:
        */
-      debug(ret == Z_OK);
+      debug_handled(ret == Z_OK);
 
       if (ret != Z_OK)
       {

--- a/pngtrans.c
+++ b/pngtrans.c
@@ -1534,8 +1534,8 @@ png_do_byte_ops_down(png_transformp *transform, png_transform_controlp tc)
    png_bytep dp = png_voidcast(png_bytep, tc->dp);
    png_alloc_size_t dest_rowbytes;
 
-   debug(tc->bit_depth == 8 || tc->bit_depth == 16);
-   debug((tc->format & PNG_FORMAT_FLAG_COLORMAP) == 0);
+   debug(tc->bit_depth == 8U || tc->bit_depth == 16U);
+   debug((tc->format & PNG_FORMAT_FLAG_COLORMAP) == 0U);
 
    tc->sp = tc->dp;
    tc->format = tr->format;
@@ -1552,24 +1552,30 @@ png_do_byte_ops_down(png_transformp *transform, png_transform_controlp tc)
       unsigned int size, hwm, i;
       png_byte output[32];
 
+      /* This catches an empty codes array, which would cause all the input to
+       * be skipped and, potentially, a garbage output[] to be written (once) to
+       * *dp.
+       */
+      affirm((codes & 0xFU) >= 4U);
+
       /* Align the writes to a 16-byte multiple from the start of the
        * destination buffer:
        */
       size = dest_rowbytes & 0xFU;
-      if (size == 0) size = 16;
-      i = size+16;
+      if (size == 0U) size = 16U;
+      i = size+16U;
       sp -= sp_advance; /* Move 1 pixel back */
-      hwm = 0;
+      hwm = 0U;
 
       for (;;)
       {
-         unsigned int next_code = code & 0xf;
+         unsigned int next_code = code & 0xFU;
 
-         if (next_code >= 8)
-            output[--i] = sp[next_code-8];
+         if (next_code >= 8U)
+            output[--i] = sp[next_code-8U];
 
-         else if (next_code >= 4)
-            output[--i] = tr->filler[next_code - 4];
+         else if (next_code >= 4U)
+            output[--i] = tr->filler[next_code - 4U];
 
          else /* end code */
          {
@@ -1593,8 +1599,8 @@ png_do_byte_ops_down(png_transformp *transform, png_transform_controlp tc)
             dp -= size;
             hwm ^= 0x10U; /* == i+16 mod 32 */
             memcpy(dp, output + hwm, size);
-            size = 16;
-            if (i == 0) i = 32;
+            size = 16U;
+            if (i == 0U) i = 32U;
          }
       }
 
@@ -1602,7 +1608,7 @@ png_do_byte_ops_down(png_transformp *transform, png_transform_controlp tc)
        * against 'hwm' before and, because of the alignment, i will always be
        * either 16 or 32:
        */
-      debug((i == 16 || i == 32) & (((i & 0x10U)^0x10U) == hwm));
+      debug((i == 16U || i == 32U) & (((i & 0x10U)^0x10U) == hwm));
       debug(sp+sp_advance == ep);
 
       /* At the end the bytes i..(hwm-1) need to be written, with the proviso
@@ -1612,24 +1618,26 @@ png_do_byte_ops_down(png_transformp *transform, png_transform_controlp tc)
        * bytes will be written (hwm == 0, i == 32) or 16 bytes need to be
        * written.
        */
-      if (size < 16)
+      if (size < 16U)
       {
-         debug(i == 16);
+         debug(i == 16U);
          dp -= size;
          memcpy(dp, output + i, size);
       }
 
       else /* size == 16 */
       {
+         debug(size == 16U);
+
          /* Write i..(hwm-1); 16 or 32 bytes, however if 32 bytes are written
           * they are contiguous and i==0.
           *
           * hwm is 0 or 16, i is 16 or 32, swap 0 and 32:
           */
-         if (hwm == 0) hwm = 32;
-         if (i == 32) i = 0;
+         if (hwm == 0U) hwm = 32U;
+         if (i == 32U) i = 0U;
          affirm(i < hwm);
-         debug(hwm == i+16 || (i == 0 && hwm == 32));
+         debug(hwm == i+16U || (i == 0U && hwm == 32U));
 
          hwm -= i;
          dp -= hwm;


### PR DESCRIPTION
These should fix most of the reported Coverity issues.  The remaining issues
should be the back_b etc assignments, which look like a Coverity bug, and
passing a pointer to a byte to a function that expects a pointer to one or more
bytes, which should (I believe) be fixed in one case and not the other
(next_filter) case; the latter case will probably go away as I am going to
rewrite that piece of code to avoid a spurious buffer allocation.

Signed-off-by: John Bowler <jbowler@acm.org>