### PR TITLE
pngvalid test changes back ported from libpng17

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,9 +51,9 @@ TESTS =\
    tests/pngvalid-gamma-expand16-background\
    tests/pngvalid-gamma-expand16-transform tests/pngvalid-gamma-sbit\
    tests/pngvalid-gamma-threshold tests/pngvalid-gamma-transform\
-   tests/pngvalid-progressive-interlace-size\
+   tests/pngvalid-progressive-size\
    tests/pngvalid-progressive-interlace-standard\
-   tests/pngvalid-progressive-interlace-transform\
+   tests/pngvalid-transform\
    tests/pngvalid-progressive-standard tests/pngvalid-standard\
    tests/pngstest-1.8 tests/pngstest-1.8-alpha tests/pngstest-linear\
    tests/pngstest-linear-alpha tests/pngstest-none tests/pngstest-none-alpha\

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -10960,6 +10960,11 @@ static const color_encoding test_encodings[] =
 /*red:  */ { 0.716500716779386, 0.258728243040113, 0.000000000000000 },
 /*green:*/ { 0.101020574397477, 0.724682314948566, 0.051211818965388 },
 /*blue: */ { 0.146774385252705, 0.016589442011321, 0.773892783545073} },
+/* Fake encoding which selects just the green channel */
+/*gamma:*/ { 1.45/2.2, /* the 'Mac' gamma */
+/*red:  */ { 0.716500716779386, 0.000000000000000, 0.000000000000000 },
+/*green:*/ { 0.101020574397477, 1.000000000000000, 0.051211818965388 },
+/*blue: */ { 0.146774385252705, 0.000000000000000, 0.773892783545073} },
 };
 
 /* signal handler
@@ -11110,7 +11115,7 @@ int main(int argc, char **argv)
 #  ifdef PNG_WRITE_tRNS_SUPPORTED
       pm.test_tRNS = 1;
 #  endif
-   pm.test_lbg = 0;
+   pm.test_lbg = PNG_LIBPNG_VER >= 10600;
    pm.test_lbg_gamma_threshold = 1;
    pm.test_lbg_gamma_transform = PNG_LIBPNG_VER >= 10600;
    pm.test_lbg_gamma_sbit = 1;

--- a/tests/pngvalid-gamma-16-to-8
+++ b/tests/pngvalid-gamma-16-to-8
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-16-to-8
+exec ./pngvalid --strict --gamma-16-to-8

--- a/tests/pngvalid-gamma-alpha-mode
+++ b/tests/pngvalid-gamma-alpha-mode
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-alpha-mode
+exec ./pngvalid --strict --gamma-alpha-mode

--- a/tests/pngvalid-gamma-background
+++ b/tests/pngvalid-gamma-background
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-background
+exec ./pngvalid --strict --gamma-background

--- a/tests/pngvalid-gamma-expand16-alpha-mode
+++ b/tests/pngvalid-gamma-expand16-alpha-mode
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-alpha-mode --expand16
+exec ./pngvalid --strict --gamma-alpha-mode --expand16

--- a/tests/pngvalid-gamma-expand16-background
+++ b/tests/pngvalid-gamma-expand16-background
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-background --expand16
+exec ./pngvalid --strict --gamma-background --expand16

--- a/tests/pngvalid-gamma-expand16-transform
+++ b/tests/pngvalid-gamma-expand16-transform
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-transform --expand16
+exec ./pngvalid --strict --gamma-transform --expand16

--- a/tests/pngvalid-gamma-sbit
+++ b/tests/pngvalid-gamma-sbit
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-sbit
+exec ./pngvalid --strict --gamma-sbit

--- a/tests/pngvalid-gamma-threshold
+++ b/tests/pngvalid-gamma-threshold
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-threshold
+exec ./pngvalid --strict --gamma-threshold

--- a/tests/pngvalid-gamma-transform
+++ b/tests/pngvalid-gamma-transform
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --gamma-transform
+exec ./pngvalid --strict --gamma-transform

--- a/tests/pngvalid-progressive-interlace-size
+++ b/tests/pngvalid-progressive-interlace-size
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec ./pngvalid --size --progressive-read

--- a/tests/pngvalid-progressive-interlace-standard
+++ b/tests/pngvalid-progressive-interlace-standard
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --standard --progressive-read --interlace
+exec ./pngvalid --strict --standard --progressive-read --interlace

--- a/tests/pngvalid-progressive-interlace-transform
+++ b/tests/pngvalid-progressive-interlace-transform
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec ./pngvalid --transform

--- a/tests/pngvalid-progressive-size
+++ b/tests/pngvalid-progressive-size
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ./pngvalid --strict --size --progressive-read

--- a/tests/pngvalid-progressive-standard
+++ b/tests/pngvalid-progressive-standard
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --standard --progressive-read
+exec ./pngvalid --strict --standard --progressive-read

--- a/tests/pngvalid-standard
+++ b/tests/pngvalid-standard
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec ./pngvalid --standard
+exec ./pngvalid --strict --standard

--- a/tests/pngvalid-transform
+++ b/tests/pngvalid-transform
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec ./pngvalid --strict --transform


### PR DESCRIPTION
A copy of pngvalid.c from libpng17 and changes to add --strict to the pngvalid tests and correct the names to match what they actually do.
