### PR TITLE
rowbytes check correction

### DIFF
--- a/pngrtran.c
+++ b/pngrtran.c
@@ -2056,10 +2056,10 @@ png_read_transform_info(png_structp png_ptr, png_infop info_ptr)
 defined(PNG_READ_USER_TRANSFORM_SUPPORTED)
    if (png_ptr->transformations & PNG_USER_TRANSFORM)
    {
-      if (info_ptr->bit_depth < png_ptr->user_transform_depth)
+      if (png_ptr->user_transform_depth)
          info_ptr->bit_depth = png_ptr->user_transform_depth;
 
-      if (info_ptr->channels < png_ptr->user_transform_channels)
+      if (png_ptr->user_transform_channels)
          info_ptr->channels = png_ptr->user_transform_channels;
    }
 #endif


### PR DESCRIPTION
The old code incorrectly calculated the output rowbytes when the
application decreased either the number of channels or the bit depth (or
both) in a user transform.  This was safe; libpng overallocated buffer
space (potentially by quite a lot; up to 4 times the amount required)
but, from 1.5.4 on, resulted in a png_error.

Signed-off-by: John Bowler <jbowler@acm.org>