### PR TITLE
rowbytes check correction

### DIFF
--- a/pngrtran.c
+++ b/pngrtran.c
@@ -2097,10 +2097,10 @@ png_read_transform_info(png_structrp png_ptr, png_inforp info_ptr)
 defined(PNG_READ_USER_TRANSFORM_SUPPORTED)
    if ((png_ptr->transformations & PNG_USER_TRANSFORM) != 0)
    {
-      if (info_ptr->bit_depth < png_ptr->user_transform_depth)
+      if (png_ptr->user_transform_depth != 0)
          info_ptr->bit_depth = png_ptr->user_transform_depth;
 
-      if (info_ptr->channels < png_ptr->user_transform_channels)
+      if (png_ptr->user_transform_channels != 0)
          info_ptr->channels = png_ptr->user_transform_channels;
    }
 #endif


### PR DESCRIPTION
The old code incorrectly calculated the output rowbytes when the
application decreased either the number of channels or the bit depth (or
both) in a user transform.  This was safe; libpng overallocated buffer
space (potentially by quite a lot; up to 4 times the amount required)
but, from 1.5.4 on, resulted in a png_error.

Signed-off-by: John Bowler <jbowler@acm.org>