### PR TITLE
pngread: avoid clang warning for unreachable code

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -2838,7 +2838,6 @@ png_image_read_colormap(png_voidp argument)
       default:
          png_error(png_ptr, "invalid PNG color type");
          /*NOT REACHED*/
-         break;
    }
 
    /* Now deal with the output processing */


### PR DESCRIPTION
```
pngread.c:2841:10: warning: 'break' will never be executed [-Wunreachable-code-break]
         break;
         ^~~~~
```