### PR TITLE
Libpng17 buffer enhancements

### DIFF
--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -36,7 +36,8 @@
 #  include <setjmp.h> /* because png.h did *not* include this */
 #endif
 
-#if defined(PNG_INFO_IMAGE_SUPPORTED) && defined(PNG_SEQUENTIAL_READ_SUPPORTED)
+#if defined(PNG_INFO_IMAGE_SUPPORTED) && defined(PNG_SEQUENTIAL_READ_SUPPORTED)\
+    && defined(PNG_READ_PNG_SUPPORTED)
 /* If a transform is valid on both read and write this implies that if the
  * transform is applied to read it must also be applied on write to produce
  * meaningful data.  This is because these transforms when performed on read
@@ -1676,7 +1677,7 @@ main(const int argc, const char * const * const argv)
       return errors != 0;
    }
 }
-#else /* !PNG_INFO_IMAGE_SUPPORTED || !PNG_READ_SUPPORTED */
+#else /* !INFO_IMAGE || !SEQUENTIAL_READ || !READ_PNG*/
 int
 main(void)
 {

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -4362,7 +4362,11 @@ png_read_process_IDAT(png_structrp png_ptr, png_bytep transformed_row,
 #                    if defined(PNG_PROGRESSIVE_READ_SUPPORTED) ||\
                         defined(PNG_READ_INTERLACING_SUPPORTED)
                         if (png_ptr->transform_list != NULL &&
-                            (save_row || (png_ptr->do_interlace && pass < 6U)))
+                            (save_row
+#                            ifdef PNG_READ_INTERLACING_SUPPORTED
+                              || (png_ptr->do_interlace && pass < 6U)
+#                            endif /* READ_INTERLACING */
+                            ))
                         {
                            if (png_ptr->transformed_row == NULL)
                               png_ptr->transformed_row = png_voidcast(png_bytep,

--- a/scripts/pnglibconf.dfa
+++ b/scripts/pnglibconf.dfa
@@ -947,7 +947,7 @@ option WRITE_zTXt enables WRITE_COMPRESSED_TEXT
 # leave the row_pointers member out of the info structure.
 
 option INFO_IMAGE disabled
-option READ_PNG requires SEQUENTIAL_READ READ_TRANSFORMS enables INFO_IMAGE
+option READ_PNG requires READ_IMAGE READ_TRANSFORMS enables INFO_IMAGE
 option WRITE_PNG requires WRITE WRITE_TRANSFORMS enables INFO_IMAGE
 
 # There are four options here, two each for read and write.  By default they are


### PR DESCRIPTION
Fixes for the code where libpng interlace handling is disabled (completely; both read and write).