### PR TITLE
Libpng17 20151124

### DIFF
--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -37,7 +37,7 @@
 #endif
 
 #if defined(PNG_INFO_IMAGE_SUPPORTED) && defined(PNG_SEQUENTIAL_READ_SUPPORTED)\
-    && defined(PNG_READ_PNG_SUPPORTED)
+    && (defined(PNG_READ_PNG_SUPPORTED) || PNG_LIBPNG_VER < 10700)
 /* If a transform is valid on both read and write this implies that if the
  * transform is applied to read it must also be applied on write to produce
  * meaningful data.  This is because these transforms when performed on read
@@ -948,7 +948,7 @@ update_display(struct display *dp)
 
          if ((transform_info[i].valid_chunks == 0 ||
                (transform_info[i].valid_chunks & chunks) != 0) &&
-            (transform_info[i].color_mask_required & ct) == 
+            (transform_info[i].color_mask_required & ct) ==
                transform_info[i].color_mask_required &&
             (transform_info[i].color_mask_absent & ct) == 0 &&
             (transform_info[i].bit_depths & bd) != 0 &&
@@ -1006,7 +1006,7 @@ compare_read(struct display *dp, int applied_transforms)
    {
       unsigned long chunks =
          png_get_valid(dp->read_pp, dp->read_ip, 0xffffffff);
-      
+
       if (chunks != dp->chunks)
          display_log(dp, APP_FAIL, "PNG chunks changed from 0x%lx to 0x%lx",
             (unsigned long)dp->chunks, chunks);


### PR DESCRIPTION
This is the pngvalid fix.   (Note that there really is only one pull request in this, but it is relative to the previous pull request).

pngvalid had one error in rgb_to_gray and an error-collection in the handling of PNG_MAX_GAMMA_8.  Correcting all the uses of the latter to match the actual behavior just eliminates one problem I was seeing in pngvalid --transform when interlace handling was disabled (the latter is irrelevant; it just causes the test cases to change.)

Since the error in PNG_MAX_GAMMA_8 caused the tests to be far more conservative wrt errors it may explain what is going on elsewhere.