### PR TITLE
Fix error in handling of bad zlib CMINFO field

### DIFF
--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -2221,7 +2221,7 @@ zlib_init(struct zlib *zlib, struct IDAT *idat, struct chunk *chunk,
    /* These values are sticky across reset (in addition to the stuff in the
     * first block, which is actually constant.)
     */
-   zlib->file_bits = 16;
+   zlib->file_bits = 24;
    zlib->ok_bits = 16; /* unset */
    zlib->cksum = 0; /* set when a checksum error is detected */
 
@@ -2304,10 +2304,12 @@ zlib_advance(struct zlib *zlib, png_uint_32 nbytes)
                zlib->file_bits = file_bits;
 
                /* Check against the existing value - it may not need to be
-                * changed.
+                * changed.  Note that a bogus file_bits is allowed through once,
+                * to see if it works, but the window_bits value is set to 15,
+                * the maximum.
                 */
                if (new_bits == 0) /* no change */
-                  zlib->window_bits = file_bits;
+                  zlib->window_bits = ((file_bits > 15) ? 15 : file_bits);
 
                else if (new_bits != file_bits) /* rewrite required */
                   bIn = (png_byte)((bIn & 0xf) + ((new_bits-8) << 4));
@@ -2328,8 +2330,7 @@ zlib_advance(struct zlib *zlib, png_uint_32 nbytes)
                if (bIn != b2)
                {
                   /* If the first byte wasn't changed this indicates an error in
-                   * the checksum calculation; signal this by setting file_bits
-                   * (not window_bits) to 0.
+                   * the checksum calculation; signal this by setting 'cksum'.
                    */
                   if (zlib->file_bits == zlib->window_bits)
                      zlib->cksum = 1;


### PR DESCRIPTION
inflate() doesn't immediately fault a bad CMINFO field, instead a 'too far back' error happens later (at least some times).  pngfix failed to limit CMINFO to the allowed values but then assumed that window_bits was in range, triggering an assert.  The bug is mostly harmless; the file can't be fixed.

Signed-off-by: John Bowler <jbowler@acm.org>