### PR TITLE
Fix undefined behavior in pngvalid.c

### DIFF
--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -305,7 +305,7 @@ static void r16(png_uint_16p p16, size_t count)
    {
       unsigned char b2[2];
       randomize(b2, sizeof b2);
-      *p16++ = 0xFFFFU & ((b2[1] << 8) + b2[0]);
+      *p16++ = png_get_uint_16(b2);
    }
 }
 
@@ -322,7 +322,7 @@ static void r32(png_uint_32p p32, size_t count)
    {
       unsigned char b4[4];
       randomize(b4, sizeof b4);
-      *p32++ = (b4[3] << 24) + (b4[2] << 16) + (b4[1] << 8) + b4[0];
+      *p32++ = png_get_uint_32(b4);
    }
 }
 


### PR DESCRIPTION
Duh: I meant to create a pull request for 1.6, I will do so now.  1.7 should be fine with the same change (i.e. with this pull request).

Undefined because (png_byte) << shift is undefined if it changes the signed bit
(because png_byte is promoted to int).  The libpng exported functions
png_get_uint_32 and png_get_uint_16 handle this.

Bug reported by David Drysdale as a result of reports from UBSAN in clang 3.8.

This changes pngvalid to use BE random numbers; this used to produce errors but
these should now be fixed as a result of the previous changes.

This change can be cherry-picked into both 1.7 and 1.5 (when the previous change to pngvalid.c has been merged).  I'll submit merge requests when I'm sure all the tests still pass.

Signed-off-by: John Bowler <jbowler@acm.org>