### PR TITLE
Restore UBSAN clean build

### DIFF
--- a/pngwutil.c
+++ b/pngwutil.c
@@ -482,10 +482,10 @@ png_zlib_compress_validate(png_zlib_compressp pz, int in_use)
 
    if (pz->overflow == 0U && pz->len == 0U && pz->start == 0U) /* empty */
    {
-      affirm((pz->end == &pz->list->next && pz->zs.next_out == pz->list->output
-               && pz->zs.avail_out == o_size) ||
-             (pz->end == &pz->list && pz->zs.next_out == NULL
-               && pz->zs.avail_out == 0U));
+      affirm((pz->end == &pz->list && pz->zs.next_out == NULL
+              && pz->zs.avail_out == 0U) ||
+             (pz->end == &pz->list->next && pz->zs.next_out == pz->list->output
+              && pz->zs.avail_out == o_size));
    }
 
    else /* not empty */


### PR DESCRIPTION
After commit 156006bb1a4eb8e041 a UBSAN build started showing a bunch of errors like:

```pngwutil.c:485:7: runtime error: member access within null pointer of type 'struct png_compression_buffer'```
