### PR TITLE
tIME and text position handling

### DIFF
--- a/pnginfo.h
+++ b/pnginfo.h
@@ -118,6 +118,7 @@ struct png_info_def
     * modified.  See the png_time struct for the contents of this struct.
     */
    png_time mod_time;
+   png_byte time_location;
 #endif
 
 #ifdef PNG_sBIT_SUPPORTED

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1150,12 +1150,12 @@ PNG_INTERNAL_FUNCTION(void,png_write_hIST,(png_structrp png_ptr,
 /* Chunks that have keywords */
 #ifdef PNG_WRITE_tEXt_SUPPORTED
 PNG_INTERNAL_FUNCTION(void,png_write_tEXt,(png_structrp png_ptr,
-   png_const_charp key, png_const_charp text, png_size_t text_len),PNG_EMPTY);
+    png_const_charp key, png_const_charp text, png_size_t text_len),PNG_EMPTY);
 #endif
 
 #ifdef PNG_WRITE_zTXt_SUPPORTED
-PNG_INTERNAL_FUNCTION(void,png_write_zTXt,(png_structrp png_ptr, png_const_charp
-    key, png_const_charp text, int compression),PNG_EMPTY);
+PNG_INTERNAL_FUNCTION(void,png_write_zTXt,(png_structrp png_ptr,
+    png_const_charp key, png_const_charp text, int compression),PNG_EMPTY);
 #endif
 
 #ifdef PNG_WRITE_iTXt_SUPPORTED

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -400,9 +400,6 @@ struct png_struct_def
    unsigned int palette_index_check_disabled :1; /* defaults to 0, 'enabled' */
    unsigned int palette_index_check_issued :1;   /* error message output */
 #endif /* CHECK_FOR_INVALID_INDEX */
-#ifdef PNG_WRITE_tIME_SUPPORTED
-   unsigned int wrote_tIME :1; /* Stop writing of duplicate tIME chunks */
-#endif /* WRITE_tIME */
 #ifdef PNG_READ_tRNS_SUPPORTED
    png_color_16 trans_color;   /* transparent color for non-paletted files */
 #endif /* READ_tRNS */

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -2218,12 +2218,6 @@ png_write_tIME(png_structrp png_ptr, png_const_timep mod_time)
       return;
    }
 
-   /* Duplicate tIME chunks are invalid; this works round a bug in png_write_png
-    * where it would write the tIME chunk once before and once after the IDAT.
-    */
-   if (png_ptr->wrote_tIME)
-      return;
-
    png_save_uint_16(buf, mod_time->year);
    buf[2] = mod_time->month;
    buf[3] = mod_time->day;
@@ -2232,7 +2226,6 @@ png_write_tIME(png_structrp png_ptr, png_const_timep mod_time)
    buf[6] = mod_time->second;
 
    png_write_complete_chunk(png_ptr, png_tIME, buf, (png_size_t)7);
-   png_ptr->wrote_tIME = 1U;
 }
 #endif
 


### PR DESCRIPTION
The handling of tIME and text chunks on read now records the location of the
chunks relative to PLTE and IDAT.  Behavior on write is unchanged except that if
the position was recorded on read it will be re-used.

This involves an ABI change to the png_text_struct; a one byte location field is
added (with the same meaning as the one used to record unknown chunk location.)
Because this field is only used on read there is no API change unless a png_info
from a libpng read is passed to a subsequent libpng write (this did not work
very well before 1.7; the tIME chunk could get duplicated.)

png_set_text ignores the new field, resetting it to the current position in the
read or write stream.  On write the position is set to the next location to be
written unless the write has not started (the position is before the signature)
in which case the location is set to PNG_HAVE_PLTE|PNG_AFTER_IDAT.  When the
chunk is written the position is set to the actual write location (effectively
the position is frozen.)

Signed-off-by: John Bowler <jbowler@acm.org>