### PR TITLE
Mark 'limit' UNUSED in transform_range_check

### DIFF
--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -6370,6 +6370,8 @@ transform_range_check(png_const_structp pp, unsigned int r, unsigned int g,
 
       png_error(pp, message);
    }
+
+   UNUSED(limit)
 }
 
 static void


### PR DESCRIPTION
Only affects release builds

Signed-off-by: John Bowler <jbowler@acm.org>