### PR TITLE
Batched fixes for read and write code

### DIFF
--- a/png.h
+++ b/png.h
@@ -1113,11 +1113,21 @@ PNG_EXPORTA(5, png_structp, png_create_write_struct,
     png_error_ptr warn_fn),
     PNG_ALLOCATED);
 
-PNG_EXPORT(6, size_t, png_get_compression_buffer_size,
+/* These APIs control the sie of the buffer used when reading IDAT chunks in the
+ * sequential read code and the size of the IDAT chunks produced when writing.
+ * They have no effect on the progressive read code.  In both read and write
+ * cases it will be necessary to allocate at least this amount of buffer space.
+ * The default value is PNG_IDAT_READ_SIZE on read and PNG_ZBUF_SIZE on write.
+ *
+ * The valid range is 1..0x7FFFFFFF on write and 1..max(uInt) on read, where
+ * uInt is the type declared by zlib.h.  On write setting the largest value will
+ * typically cause the PNG image data to be written in one chunk; this gives the
+ * smallest PNG and has little or no effect on applications that read the PNG.
+ */
+PNG_EXPORT(6, png_alloc_size_t, png_get_compression_buffer_size,
     (png_const_structrp png_ptr));
-
 PNG_EXPORT(7, void, png_set_compression_buffer_size, (png_structrp png_ptr,
-    size_t size));
+    png_alloc_size_t size));
 
 /* Moved from pngconf.h in 1.4.0 and modified to ensure setjmp/longjmp
  * match up.

--- a/pngget.c
+++ b/pngget.c
@@ -1144,7 +1144,7 @@ png_get_user_chunk_ptr(png_const_structrp png_ptr)
 }
 #endif
 
-png_size_t PNGAPI
+png_alloc_size_t PNGAPI
 png_get_compression_buffer_size(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)

--- a/pngset.c
+++ b/pngset.c
@@ -1596,16 +1596,17 @@ png_set_rows(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 void PNGAPI
-png_set_compression_buffer_size(png_structrp png_ptr, png_size_t size)
+png_set_compression_buffer_size(png_structrp png_ptr, png_alloc_size_t size)
 {
    if (png_ptr == NULL)
       return;
 
-   if (size == 0 || size > PNG_UINT_31_MAX)
+   if (size == 0 ||
+       size > (png_ptr->read_struct ? ZLIB_IO_MAX : PNG_UINT_31_MAX))
       png_error(png_ptr, "invalid compression buffer size");
 
 #  if (defined PNG_SEQUENTIAL_READ_SUPPORTED) || defined PNG_WRITE_SUPPORTED
-      png_ptr->IDAT_size = (uInt)/*SAFE*/size;
+      png_ptr->IDAT_size = (png_uint_32)/*SAFE*/size;
 #  endif /* SEQUENTIAL_READ || WRITE */
 }
 

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -576,7 +576,7 @@ struct png_struct_def
 #endif
 
 #if defined(PNG_SEQUENTIAL_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
-   uInt IDAT_size; /* limit on IDAT read and write IDAT size */
+   png_uint_32 IDAT_size;         /* limit on IDAT read and write IDAT size */
 #endif /* SEQUENTIAL_READ || WRITE */
 
    /* ERROR HANDLING */

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -2363,7 +2363,8 @@ png_write_IDAT(png_structrp png_ptr, int flush)
          else /* not end of list */
             debug((ps->s.zs.next_out < next->output ||
                    ps->s.zs.next_out > next->output + sizeof next->output) &&
-                  (ps->s.overflow > 0 || ps->s.len >= sizeof next->output));
+                  (ps->s.overflow > 0 ||
+                   ps->s.start + ps->s.len >= sizeof next->output));
 
          /* First, if this is the very first IDAT (PNG_HAVE_IDAT not set)
           * optimize the CINFO field:
@@ -2419,7 +2420,6 @@ png_write_IDAT(png_structrp png_ptr, int flush)
             written = len;
             png_write_chunk_data(png_ptr, next->output+start, written);
             ps->s.start = (unsigned int)/*SAFE*/(start + written);
-            UNTESTED
          }
 
          /* 'written' bytes were written: */


### PR DESCRIPTION
The read fix fixes a warning and possible portability problems in the IDAT buffering.  The write fix fixes and incorrect debug assert.  The pngcp change allows testing of different (write) IDAT sizes.