### PR TITLE
Recently introduced palette sharing bug

### DIFF
--- a/contrib/examples/pngcp.c
+++ b/contrib/examples/pngcp.c
@@ -130,7 +130,7 @@ vl_strategy[] =
 vl_windowBits_text[] =
 {
    { "default", 15 },
-   { "small", 9 },
+   { "minimum", 8 },
    RANGE(8, 15),
    { all, 0 }
 },
@@ -147,9 +147,12 @@ vl_level[] =
 },
 vl_memLevel[] =
 {
-   { "default", 8 },
-   { "least", 1 },
-   RANGE(2, 9), /* exclude 1: there seems to be a zlib bug */
+   { "9", 9 }, /* zlib maximum */
+   { "1", 1 }, /* zlib minimum */
+   { "default", 8 }, /* zlib default */
+   { "2", 2 },
+   { "3", 3 }, /* for explicit testing */
+   RANGE(4, 9), /* exclude 3 and below: zlib bugs */
    { all, 0 }
 },
 #endif /* WRITE_CUSTOMIZE_*COMPRESSION */
@@ -1052,7 +1055,7 @@ getsearchopts(struct display *dp, const char *opt_str, int *value)
    }
 
    else if (opt == OPTIND(dp, memLevel))
-      dp->value[opt] = 9; /* fixed */
+      (void)advance_opt(dp, opt, 1/*search*/);
 
    else /* something else */
       return 0;

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -469,7 +469,7 @@ struct png_struct_def
        * default: PNG_DEFAULT_GAMMA_ACCURACY (665)
        */
 #endif /* NYI */
-   png_uint_16      gamma_threshold;
+   png_uint_16  gamma_threshold;
       /* Gamma threshold value as a fixed-point value in the range 0..1; the
        * threshold at or below which gamma correction is skipped.  '0' forces
        * gamma correction even when there is none because the input and output
@@ -479,7 +479,8 @@ struct png_struct_def
        */
 #endif /* READ_GAMMA */
 #ifdef PNG_READ_TRANSFORMS_SUPPORTED
-   unsigned int     invalid_info;     /* PNG_INFO_* for invalidated chunks */
+   unsigned int invalid_info;      /* PNG_INFO_* for invalidated chunks */
+   unsigned int palette_updated:1; /* png_struct::palette changed */
 #endif /* READ_TRANSFORMS */
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED


### PR DESCRIPTION
The internal read code change to stop sharing the palette was incompletely
implemented.  The result is that unless palette index checking is turned off and
there are no read transformations the png_info palette gets deleted when the
png_struct is deleted.  This is normally harmless (png_info gets deleted first)
but in the case of pngcp it results in use-after-free of the palette and,
therefore, palette corruption and maybe on some operating systems and access
violation.

This also updated pngcp 'search' mode to check a restricted range of memLevels;
there is an unrelated bug which means that lower zlib memLevels result in memory
corruption under some circumstances, probably less often than 1:1000.

Signed-off-by: John Bowler <jbowler@acm.org>