### PR TITLE
PNG_IMAGE_PNG_SIZE_MAX error correction

### DIFF
--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -3209,7 +3209,11 @@ write_one_file(Image *output, Image *image, int convert_to_8bit)
       {
          /* This is non-fatal: */
          if (size > PNG_IMAGE_PNG_SIZE_MAX(image->image))
+         {
             logerror(image, "memory", ": PNG_IMAGE_SIZE_MAX wrong", "");
+            if ((image->opts & STRICT) != 0)
+               return 0;
+         }
 
          initimage(output, image->opts, "memory", image->stride_extra);
          output->input_memory = malloc(size);
@@ -3224,7 +3228,12 @@ write_one_file(Image *output, Image *image, int convert_to_8bit)
             {
                /* This is also non-fatal (maybe): */
                if (size != output->input_memory_size)
+               {
                   logerror(image, "memory", ": memory size wrong", "");
+
+                  if ((image->opts & STRICT) != 0)
+                     return 0;
+               }
             }
 
             else

--- a/png.h
+++ b/png.h
@@ -3142,8 +3142,9 @@ PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
 #define PNG_IMAGE_PNG_SIZE_MAX_(image, image_size)\
    ((8U/*sig*/+25U/*IHDR*/+16U/*gAMA*/+44U/*cHRM*/+12U/*IEND*/+\
     (((image).format&PNG_FORMAT_FLAG_COLORMAP)?/*colormap: PLTE, tRNS*/\
-     12U+PNG_IMAGE_COLORMAP_SIZE(image)/*PLTE+tRNS data*/+\
-     (((image).format&PNG_FORMAT_FLAG_ALPHA)?12U/*tRNS*/:0U):0U)+\
+     12U+3U*(image).colormap_entries/*PLTE data*/+\
+     (((image).format&PNG_FORMAT_FLAG_ALPHA)?\
+      12U/*tRNS*/+(image).colormap_entries:0U):0U)+\
     12U)+(12U*((image_size)/PNG_ZBUF_SIZE))/*IDAT*/+(image_size))
    /* A helper for the following macro; if your compiler cannot handle the
     * following macro use this one with the result of


### PR DESCRIPTION
The macro underreported the size (by up to 512 bytes) of an 8-bit non-color
palette based memory format because it failed to take into account that the
memory palette has to be expanded to full RGB when it is written to PNG.

This is not likely to be a serious bug because the macro is new, the memory
format in question is likely to be rarely used and the result of an undersized
buffer fails in a safe way.

Signed-off-by: John Bowler <jbowler@acm.org>