### PR TITLE
pngstest: options to fix per-file seed

### DIFF
--- a/tests/pngstest
+++ b/tests/pngstest
@@ -17,36 +17,38 @@ gamma="$1"
 shift
 alpha="$1"
 shift
-exec ./pngstest --tmpfile "${gamma}-${alpha}-" --log ${1+"$@"} `
-   for f in "${srcdir}/contrib/testpngs/"*.png
-   do
-      g=
-      case "$f" in
-         *-linear[.-]*)
-            test "$gamma" = "linear" && g="$f";;
+args=
+LC_ALL="C" # fix glob sort order to ASCII:
+for f in "${srcdir}/contrib/testpngs/"*.png
+do
+   g=
+   case "$f" in
+      *-linear[.-]*)
+         test "$gamma" = "linear" && g="$f";;
 
-         *-sRGB[.-]*)
-            test "$gamma" = "sRGB" && g="$f";;
+      *-sRGB[.-]*)
+         test "$gamma" = "sRGB" && g="$f";;
 
-         *-1.8[.-]*)
-            test "$gamma" = "1.8" && g="$f";;
+      *-1.8[.-]*)
+         test "$gamma" = "1.8" && g="$f";;
 
-         *)
-            test "$gamma" = "none" && g="$f";;
-      esac
+      *)
+         test "$gamma" = "none" && g="$f";;
+   esac
 
-      case "$g" in
-         "")
-            :;;
+   case "$g" in
+      "")
+         :;;
 
-         *-alpha[-.]*)
-            test "$alpha" = "alpha" && echo "$g";;
+      *-alpha[-.]*)
+         test "$alpha" = "alpha" && args="$args $g";;
 
-         *-tRNS[-.]*)
-            test "$alpha" = "tRNS" -o "$alpha" = "none" && echo "$g";;
+      *-tRNS[-.]*)
+         test "$alpha" = "tRNS" -o "$alpha" = "none" && args="$args $g";;
 
-         *)
-            test "$alpha" = "opaque" -o "$alpha" = "none" && echo "$g";;
-      esac
-   done
-`
+      *)
+         test "$alpha" = "opaque" -o "$alpha" = "none" && args="$args $g";;
+   esac
+done
+# This only works if the arguments don't contain spaces; they don't.
+exec ./pngstest --tmpfile "${gamma}-${alpha}-" --log ${1+"$@"} $args


### PR DESCRIPTION
Also avoid command output substition in tests/pngstest and fix the collation
locale to ASCII/C/POSIX

Signed-off-by: John Bowler <jbowler@acm.org>