### PR TITLE
Fix win errors:

### DIFF
--- a/scripts/genout.cmake.in
+++ b/scripts/genout.cmake.in
@@ -14,7 +14,7 @@ set(BINDIR "@CMAKE_CURRENT_BINARY_DIR@")
 
 set(AWK "@AWK@")
 set(CMAKE_C_COMPILER "@CMAKE_C_COMPILER@")
-set(CMAKE_C_FLAGS "@CMAKE_C_FLAGS@")
+set(CMAKE_C_FLAGS @CMAKE_C_FLAGS@)
 set(INCDIR "@CMAKE_CURRENT_BINARY_DIR@")
 set(PNG_PREFIX "@PNG_PREFIX@")
 set(PNGLIB_MAJOR "@PNGLIB_MAJOR@")
@@ -48,6 +48,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
                           ${CMAKE_C_FLAGS}
                           "-I${SRCDIR}"
                           "-I${BINDIR}"
+                          ${INCLUDES}
                           "-DPNGLIB_LIBNAME=PNG${PNGLIB_MAJOR}${PNGLIB_MINOR}_0"
                           "-DPNGLIB_VERSION=${PNGLIB_VERSION}"
                           "-DSYMBOL_PREFIX=${SYMBOL_PREFIX}"


### PR DESCRIPTION
These are the errors that I came across and my fixes (using cmake on Windows):
- fatal error C1083: Cannot open source file: ' /DWIN32 /D_WINDOWS /W3': No such file or directory [~\genfiles.vcxproj]
  - removed quotes from line 17; set as a list to strip leading spaces
- fatal error C1083: Cannot open include file: 'zlib.h': No such file or directory [~\genfiles.vcxproj]
  - added line 51; INCLUDES was set but not used in execute_process