### PR TITLE
Add support to use multiple directories in ZLIBINCDIR variable

### DIFF
--- a/scripts/genout.cmake.in
+++ b/scripts/genout.cmake.in
@@ -37,7 +37,9 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
 
   set(INCLUDES "-I${INCDIR}")
   if(ZLIBINCDIR)
-    list(APPEND INCLUDES "-I${ZLIBINCDIR}")
+    foreach(dir ${ZLIBINCDIR})
+      list(APPEND INCLUDES "-I${dir}")
+    endforeach()
   endif()
 
   if(PNG_PREFIX)


### PR DESCRIPTION
For example, ZLIB_INCLUDE_DIR might include the directory where zlib.h is located (source dir) and the zconf.h file is located (binary dir).