### PR TITLE
Fix pnglibconf.c compilation on OS X including the sysroot path

### DIFF
--- a/scripts/genout.cmake.in
+++ b/scripts/genout.cmake.in
@@ -22,6 +22,13 @@ set(PNGLIB_MINOR "@PNGLIB_MINOR@")
 set(PNGLIB_VERSION "@PNGLIB_VERSION@")
 set(ZLIBINCDIR "@ZLIB_INCLUDE_DIR@")
 
+set(PLATFORM_C_FLAGS)
+if(APPLE)
+  set(CMAKE_OSX_ARCHITECTURES "@CMAKE_OSX_ARCHITECTURES@")
+  set(CMAKE_OSX_SYSROOT "@CMAKE_OSX_SYSROOT@")
+  set(PLATFORM_C_FLAGS -arch ${CMAKE_OSX_ARCHITECTURES} -isysroot ${CMAKE_OSX_SYSROOT})
+endif()
+
 get_filename_component(INPUTEXT "${INPUT}" EXT)
 get_filename_component(OUTPUTEXT "${OUTPUT}" EXT)
 get_filename_component(INPUTBASE "${INPUT}" NAME_WE)
@@ -46,6 +53,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
 
   execute_process(COMMAND "${CMAKE_C_COMPILER}" "-E"
                           ${CMAKE_C_FLAGS}
+                          ${PLATFORM_C_FLAGS}
                           "-I${SRCDIR}"
                           "-I${BINDIR}"
                           ${INCLUDES}


### PR DESCRIPTION
Without these flags pnglibconf.c compilation fails because it includes zlib.h -> zconf.h -> sys/types.h which is not found until we give a correct SDK path with -isysroot flag.