### PR TITLE
Minor write bug-fixes, remove unimplemented code

### DIFF
--- a/png.h
+++ b/png.h
@@ -1226,11 +1226,12 @@ PNG_EXPORT(241, int, png_convert_to_rfc1123_buffer, (char out[29],
 
 #ifdef PNG_CONVERT_tIME_SUPPORTED
 /* Convert from a struct tm to png_time */
-PNG_EXPORT(24, void, png_convert_from_struct_tm, (png_timep ptime,
-    const struct tm * ttime));
+PNG_EXPORT(24, PNG_DEPRECATED void, png_convert_from_struct_tm,
+      (png_timep ptime, const struct tm * ttime));
 
 /* Convert from time_t to png_time.  Uses gmtime() */
-PNG_EXPORT(25, void, png_convert_from_time_t, (png_timep ptime, time_t ttime));
+PNG_EXPORT(25, PNG_DEPRECATED void, png_convert_from_time_t, (png_timep ptime,
+         time_t ttime));
 #endif /* CONVERT_tIME */
 
 #ifdef PNG_READ_EXPAND_SUPPORTED

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1211,10 +1211,11 @@ PNG_INTERNAL_FUNCTION(void,png_write_start_IDAT,(png_structrp png_ptr),
  */
 enum
 {
-   png_row_end        =0x1U, /* This is the last block in the row */
-   png_pass_first_row =0x2U, /* This is the first row in a pass */
-   png_pass_last_row  =0x4U, /* This is the last row in a pass */
-   png_pass_last      =0x8U  /* This is the last pass in the image */
+   png_pass_last      =0x1U, /* This is the last pass in the image */
+   png_pass_last_row  =0x2U, /* This is the last row in a pass */
+   png_pass_first_row =0x4U, /* This is the first row in a pass */
+   png_row_end        =0x8U, /* This is the last block in the row */
+   png_no_row_info    =0x0U  /* Placeholder */
 
    /* A useful macro; return true if this is the last block of the last row in
     * the image.


### PR DESCRIPTION
A debug() assert fired if windowBits was set to 8 for the Huffman only and
no-compression cases.  This commit changes it to do some extra checking.  Remove
unreachable code in pz_default_settings, eliminate a spurious warning in pngcp
for small files.

Signed-off-by: John Bowler <jbowler@acm.org>