### PR TITLE
Fix png encoding perf regression in libpng 1.6

### DIFF
--- a/pngwutil.c
+++ b/pngwutil.c
@@ -2270,9 +2270,6 @@ png_setup_sub_row(png_structrp png_ptr, const png_uint_32 bpp,
    {
       v = *dp = (png_byte)(((int)*rp - (int)*lp) & 0xff);
       sum += (v < 128) ? v : 256 - v;
-
-      if (sum > lmins)  /* We are already worse, don't continue. */
-        break;
    }
 
    return (sum);
@@ -2295,9 +2292,6 @@ png_setup_up_row(png_structrp png_ptr, const png_size_t row_bytes,
    {
       v = *dp = (png_byte)(((int)*rp - (int)*pp) & 0xff);
       sum += (v < 128) ? v : 256 - v;
-
-      if (sum > lmins)  /* We are already worse, don't continue. */
-        break;
    }
 
    return (sum);


### PR DESCRIPTION
Applications that care about encoding performance may choose to
select a fast encoding filter.  Ex:
png_set_filter(png, PNG_FILTER_TYPE_BASE, PNG_FILTER_SUB);
or
png_set_filter(png, PNG_FILTER_TYPE_BASE, PNG_FILTER_UP);

This improves encode performance (1) because applying the filter
is fast and (2) because we have selected a single filter, there
is no need to calculate and track filter choosing heuristics.

libpng 1.2 takes advantage of both (1) and (2), but I'm seeing a
significant performance regression in libpng 1.6 (1.75x slower on
a particular benchmark) because it does not take advantage of (2).
png_setup_sub_row() is inlined, so the compiler should be able to
detect that "sum" is unused and decide not to calculate it.
However, since we check the "sum" on every loop iteration, the sum
is being calculated regardless of whether we need it or not.

I'm proposing that we don't bother to check (sum > lmin) on the
"fast filters" since they are fast anyway (so it's not too bad to
complete the entire row, even if it turns out to be unnecessary).
This will make them much faster when they are the only filter
selected.

Another potential fix would be to actually inline the
png_setup_sub_row() code (like libpng 1.2 does) rather than
sharing the code in a function.

Let me know what you think!