### PR TITLE
SKIP definition in pngstest.c misplaced

### DIFF
--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -26,15 +26,6 @@
 #  include <config.h>
 #endif
 
-/* 1.6.1 added support for the configure test harness, which uses 77 to indicate
- * a skipped test, in earlier versions we need to succeed on a skipped test, so:
- */
-#if PNG_LIBPNG_VER >= 10601 && defined(HAVE_CONFIG_H)
-#  define SKIP 77
-#else
-#  define SKIP 0
-#endif
-
 /* Define the following to use this test against your installed libpng, rather
  * than the one being built here:
  */
@@ -42,6 +33,15 @@
 #  include <png.h>
 #else
 #  include "../../png.h"
+#endif
+
+/* 1.6.1 added support for the configure test harness, which uses 77 to indicate
+ * a skipped test, in earlier versions we need to succeed on a skipped test, so:
+ */
+#if PNG_LIBPNG_VER >= 10601 && defined(HAVE_CONFIG_H)
+#  define SKIP 77
+#else
+#  define SKIP 0
 #endif
 
 #ifdef PNG_SIMPLIFIED_READ_SUPPORTED /* Else nothing can be done */


### PR DESCRIPTION
The SKIP definition needs to come after the png.h include (see all the other .c
files in contrib/libtests) because it depends on PNG_LIBPNG_VER.  This commit
puts it in the correct place.

Signed-off-by: John Bowler <jbowler@acm.org>