### PR TITLE
pngimage: correct #define checking (cherry-picked from libpng17)

### DIFF
--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -2,7 +2,7 @@
  *
  * Copyright (c) 2015,2016 John Cunningham Bowler
  *
- * Last changed in libpng 1.6.24 [(PENDING RELEASE)]
+ * Last changed in libpng 1.6.22 [May 26, 2016]
  *
  * This code is released under the libpng license.
  * For conditions of distribution and use, see the disclaimer
@@ -45,8 +45,19 @@
 #  define SKIP 0
 #endif
 
-#if defined(PNG_INFO_IMAGE_SUPPORTED) && defined(PNG_SEQUENTIAL_READ_SUPPORTED)\
-    && (defined(PNG_READ_PNG_SUPPORTED) || PNG_LIBPNG_VER < 10700)
+#if PNG_LIBPNG_VER < 10700
+   /* READ_PNG and WRITE_PNG were not defined, so: */
+#  ifdef PNG_INFO_IMAGE_SUPPORTED
+#     ifdef PNG_SEQUENTIAL_READ_SUPPORTED
+#        define PNG_READ_PNG_SUPPORTED
+#     endif /* SEQUENTIAL_READ */
+#     ifdef PNG_WRITE_SUPPORTED
+#        define PNG_WRITE_PNG_SUPPORTED
+#     endif /* WRITE */
+#  endif /* INFO_IMAGE */
+#endif /* pre 1.7.0 */
+
+#ifdef PNG_READ_PNG_SUPPORTED
 /* If a transform is valid on both read and write this implies that if the
  * transform is applied to read it must also be applied on write to produce
  * meaningful data.  This is because these transforms when performed on read
@@ -395,7 +406,7 @@ buffer_destroy(struct buffer *buffer)
    buffer_destroy_list(list);
 }
 
-#ifdef PNG_WRITE_SUPPORTED
+#ifdef PNG_WRITE_PNG_SUPPORTED
 static void
 buffer_start_write(struct buffer *buffer)
 {
@@ -565,7 +576,7 @@ struct display
    png_structp    read_pp;
    png_infop      read_ip;
 
-#  ifdef PNG_WRITE_SUPPORTED
+#  ifdef PNG_WRITE_PNG_SUPPORTED
       /* Used to write a new image (the original info_ptr is used) */
       png_structp   write_pp;
       struct buffer written_file;   /* where the file gets written */
@@ -592,7 +603,7 @@ display_init(struct display *dp)
    dp->read_ip = NULL;
    buffer_init(&dp->original_file);
 
-#  ifdef PNG_WRITE_SUPPORTED
+#  ifdef PNG_WRITE_PNG_SUPPORTED
       dp->write_pp = NULL;
       buffer_init(&dp->written_file);
 #  endif
@@ -605,7 +616,7 @@ display_clean_read(struct display *dp)
       png_destroy_read_struct(&dp->read_pp, &dp->read_ip, NULL);
 }
 
-#ifdef PNG_WRITE_SUPPORTED
+#ifdef PNG_WRITE_PNG_SUPPORTED
 static void
 display_clean_write(struct display *dp)
 {
@@ -617,7 +628,7 @@ display_clean_write(struct display *dp)
 static void
 display_clean(struct display *dp)
 {
-#  ifdef PNG_WRITE_SUPPORTED
+#  ifdef PNG_WRITE_PNG_SUPPORTED
       display_clean_write(dp);
 #  endif
    display_clean_read(dp);
@@ -635,7 +646,7 @@ static void
 display_destroy(struct display *dp)
 {
     /* Release any memory held in the display. */
-#  ifdef PNG_WRITE_SUPPORTED
+#  ifdef PNG_WRITE_PNG_SUPPORTED
       buffer_destroy(&dp->written_file);
 #  endif
 
@@ -1253,7 +1264,7 @@ compare_read(struct display *dp, int applied_transforms)
    return 1; /* compare succeeded */
 }
 
-#ifdef PNG_WRITE_SUPPORTED
+#ifdef PNG_WRITE_PNG_SUPPORTED
 static void
 buffer_write(struct display *dp, struct buffer *buffer, png_bytep data,
    png_size_t size)
@@ -1352,7 +1363,7 @@ write_png(struct display *dp, png_infop ip, int transforms)
     */
    display_clean_write(dp);
 }
-#endif /* WRITE_SUPPORTED */
+#endif /* WRITE_PNG */
 
 static int
 skip_transform(struct display *dp, int tr)
@@ -1414,7 +1425,7 @@ test_one_file(struct display *dp, const char *filename)
          return; /* no point testing more */
    }
 
-#ifdef PNG_WRITE_SUPPORTED
+#ifdef PNG_WRITE_PNG_SUPPORTED
    /* Second test: write the original PNG data out to a new file (to test the
     * write side) then read the result back in and make sure that it hasn't
     * changed.
@@ -1455,7 +1466,7 @@ test_one_file(struct display *dp, const char *filename)
           * out and read it back in again (without the reversible transforms)
           * we should get back to the place where we started.
           */
-#ifdef PNG_WRITE_SUPPORTED
+#ifdef PNG_WRITE_PNG_SUPPORTED
          if ((current & write_transforms) == current)
          {
             /* All transforms reversible: write the PNG with the transformations
@@ -1691,7 +1702,7 @@ main(const int argc, const char * const * const argv)
       return errors != 0;
    }
 }
-#else /* !INFO_IMAGE || !SEQUENTIAL_READ || !READ_PNG*/
+#else /* !READ_PNG */
 int
 main(void)
 {


### PR DESCRIPTION
In libpng 1.7 pngimage needs to check PNG_WRITE_PNG_SUPPORTED (new in 1.7), not
PNG_WRITE_SUPPORTED because png_write_png can be disabled without disabling
PNG_WRITE_SUPPORTED.  Copied the approach from 1.6 pngcp.c (so this still works
in 1.6 as well.)