### PR TITLE
Fix debug test of output gamma

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -2117,6 +2117,14 @@ PNG_INTERNAL_FUNCTION(unsigned int,png_gamma_nxmbit_correct,
    /* In this case the value must have 'n' bits and the output will have 'm'
     * bits.
     */
+
+#if !PNG_RELEASE_BUILD
+PNG_INTERNAL_FUNCTION(int,png_gamma_check,(png_const_structrp png_ptr,
+   png_const_transform_controlp tc),PNG_EMPTY);
+   /* Debugging only routine to repeat the test used above to determine if the
+    * gamma was insignificant.
+    */
+#endif /* !RELEASE_BUILD */
 #endif /* READ_GAMMA */
 
 #ifdef PNG_SIMPLIFIED_READ_SUPPORTED

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -3434,6 +3434,26 @@ png_init_gamma(png_transformp *transform, png_transform_controlp tc)
    }
 }
 
+#if !PNG_RELEASE_BUILD
+int /* PRIVATE(debug only) */
+png_gamma_check(png_const_structrp png_ptr, png_const_transform_controlp tc)
+   /* Debugging only routine to repeat the test used above to determine if the
+    * gamma was insignificant.
+    *
+    * NOTE: JB20160723: This may still be incorrect in a complicated transform
+    * pipeline because it uses 'tc_sBIT' for the end of the pipeline whereas the
+    * init above happens earlier.  I don't think this matters because the test
+    * is only invoked if the gamma transform is eliminated or if there is a bug
+    * and in the former case the sBIT values should remain unchanged.
+    */
+{
+   png_fixed_point dummy;
+
+   return png_gamma_equal(png_ptr, png_ptr->row_gamma, tc->gamma, &dummy,
+                          tc_sBIT(tc));
+}
+#endif /* !RELEASE_BUILD */
+
 static png_fixed_point
 translate_gamma_flags(png_const_structrp png_ptr, png_fixed_point gamma,
     int is_screen)

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -4309,10 +4309,11 @@ png_read_process_IDAT(png_structrp png_ptr, png_bytep transformed_row,
                         png_ptr->row_range == tc.range &&
                         png_ptr->row_bit_depth == tc.bit_depth);
 #                    ifdef PNG_READ_GAMMA_SUPPORTED
-                        /* This sometimes fails at present when gamma
-                         * transforms are eliminated in PNG_TC_INIT_FINAL:
+                        /* This checks the output gamma taking into account the
+                         * fact that small gamma changes are eliminated.
                          */
-                        debug(png_ptr->row_gamma == tc.gamma);
+                        debug(png_ptr->row_gamma == tc.gamma ||
+                              png_gamma_check(png_ptr, &tc));
 #                    endif /* READ_GAMMA */
 
                      /* If the caller needs the row saved (for the progressive


### PR DESCRIPTION
The test would fire when a gamma transform was eliminated because it was not
significant if other transforms remained.  This is a debug-only change to alter
the test to check for an insignificant mis-match of the actual output gamma from
the requested output gamma.

Signed-off-by: John Bowler <jbowler@acm.org>