### PR TITLE
added PNG_ARM_NEON switch and enabled building with NEON support with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,30 @@ option(PNGARG        "Disable ANSI-C prototypes" OFF)
 set(PNG_PREFIX "" CACHE STRING "Prefix to add to the API function names")
 set(DFA_XTRA "" CACHE FILEPATH "File containing extra configuration settings")
 
+# set definitions and sources for arm
+if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "^arm")
+  set(PNG_ARM_NEON_POSSIBLE_VALUES check on off)
+  set(PNG_ARM_NEON "check" CACHE STRING "Enable ARM NEON optimizations: =check on off; check: use internal checking code; off: disable the optimizations; on: turn on unconditionally. Default is 'check'")
+  set_property(CACHE PNG_ARM_NEON PROPERTY STRINGS ${PNG_ARM_NEON_POSSIBLE_VALUES})
+  list(FIND PNG_ARM_NEON_POSSIBLE_VALUES ${PNG_ARM_NEON} index)
+  if(index EQUAL -1)
+    message(FATAL_ERROR " PNG_ARM_NEON must be one of [${PNG_ARM_NEON_POSSIBLE_VALUES}]")
+  elseif(NOT ${PNG_ARM_NEON} STREQUAL "no")
+    set(libpng_arm_sources
+      arm/arm_init.c
+      arm/filter_neon.S
+      arm/filter_neon_intrinsics.c)
+      
+    if(${PNG_ARM_NEON} STREQUAL "on")
+      add_definitions(-DPNG_ARM_NEON_OPT=2)
+    elseif(${PNG_ARM_NEON} STREQUAL "check")
+      add_definitions(-DPNG_ARM_NEON_CHECK_SUPPORTED)
+    endif()
+  else()
+    add_definitions(-DPNG_ARM_NEON_OPT=0)
+  endif()
+endif()
+
 # SET LIBNAME
 set(PNG_LIB_NAME png${PNGLIB_MAJOR}${PNGLIB_MINOR})
 
@@ -342,6 +366,7 @@ if(AWK)
   list(APPEND libpng_private_hdrs "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h")
 endif()
 set(libpng_sources
+  ${libpng_arm_sources}
   ${libpng_public_hdrs}
   ${libpng_private_hdrs}
   png.c


### PR DESCRIPTION
CMAKE_SYSTEM_PROCESSOR is checked to discern whether to build for arm or not, as it is the canonical variable for this.
Behaviour is copied from autoconf; by default PNG_ARM_NEON is set to 'check' and NEON support is checked dynamically at runtime. Other possible values are 'on' and 'off'. The deprecated option 'api' is not used here.
