### PR TITLE
Libpng15

### DIFF
--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -4010,8 +4010,11 @@ check_interlace_type(int const interlace_type)
 #  define do_own_interlace 1
 #endif /* WRITE_INTERLACING tests */
 
-#define CAN_WRITE_INTERLACE\
-   PNG_LIBPNG_VER >= 10700 || defined PNG_WRITE_INTERLACING_SUPPORTED
+#if PNG_LIBPNG_VER >= 10700 || defined PNG_WRITE_INTERLACING_SUPPORTED
+#   define CAN_WRITE_INTERLACE 1
+#else
+#   define CAN_WRITE_INTERLACE 0
+#endif
 
 /* Do the same thing for read interlacing; this controls whether read tests do
  * their own de-interlace or use libpng.

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1362,13 +1362,6 @@ PNG_EXTERN int png_check_cHRM_fixed PNGARG((png_structp png_ptr,
     png_fixed_point int_blue_y));
 #endif
 
-#ifdef PNG_CHECK_cHRM_SUPPORTED
-/* Added at libpng version 1.2.34 and 1.4.0 */
-/* Currently only used by png_check_cHRM_fixed */
-PNG_EXTERN void png_64bit_product PNGARG((long v1, long v2,
-    unsigned long *hi_product, unsigned long *lo_product));
-#endif
-
 #ifdef PNG_cHRM_SUPPORTED
 /* Added at libpng version 1.5.5 */
 typedef struct png_xy

--- a/pngtrans.c
+++ b/pngtrans.c
@@ -629,12 +629,16 @@ png_do_check_palette_indexes(png_structp png_ptr, png_row_infop row_info)
       png_ptr->num_palette > 0) /* num_palette can be 0 in MNG files */
    {
       /* Calculations moved outside switch in an attempt to stop different
-       * compiler warnings.  'padding' is in *bits* within the last byte, it is
-       * an 'int' because pixel_depth becomes an 'int' in the expression below,
-       * and this calculation is used because it avoids warnings that other
-       * forms produced on either GCC or MSVC.
+       * compiler warnings.
+       *
+       * 1.5.28: This rewritten version attempts to remove the unsigned integer
+       * overflow from the prior version.  While this was well defined it
+       * resulted in unsigned overflow detection in clang.  Since the result is
+       * always in the range 0..7 only the low three bits of of the various
+       * intermediates are every required, so:
        */
-      int padding = (-row_info->pixel_depth * row_info->width) & 7;
+      unsigned int padding =
+          ((8 - (row_info->pixel_depth & 7)) * (row_info->width & 7)) & 7;
       png_bytep rp = png_ptr->row_buf + row_info->rowbytes;
 
       switch (row_info->bit_depth)


### PR DESCRIPTION
Each of the patches here can be applied independently (I think); i.e. there should be no inconvenient overlap.  I recommend the first patch to ensure consistency in pngvalid; I'll send pull requests for 1.6 and 1.7 with the same patch (I just git am'ed it in each branch).

The second (unsigned overflow) patch should be harmless and, with the third patch, it allows builds with clang unsigned overflow checking to pass.  It isn't necessary; the unsigned overflow is safe, but it allows builds with that option.

The third patch fixes a genuine signed overflow problem; signed overflow behavior is undefined so it is worthwhile to fix it, however 1.5 does actually work on all the platforms it is used on (else someone would have reported this before) and this patch is moderately big for a release which has been superseded (by 1.6).