### PR TITLE
Remove 'defined' within macro

### DIFF
--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -4010,8 +4010,11 @@ check_interlace_type(int const interlace_type)
 #  define do_own_interlace 1
 #endif /* WRITE_INTERLACING tests */
 
-#define CAN_WRITE_INTERLACE\
-   PNG_LIBPNG_VER >= 10700 || defined PNG_WRITE_INTERLACING_SUPPORTED
+#if PNG_LIBPNG_VER >= 10700 || defined PNG_WRITE_INTERLACING_SUPPORTED
+#   define CAN_WRITE_INTERLACE 1
+#else
+#   define CAN_WRITE_INTERLACE 0
+#endif
 
 /* Do the same thing for read interlacing; this controls whether read tests do
  * their own de-interlace or use libpng.


### PR DESCRIPTION
This removes the use of a macro containing the pre-processor 'defined'
operator.  It is unclear whether this is valid; a macro which
"generates" 'defined' is not permitted, but the use of the work
"generates" within the C90 standard seems to imply more than simple
substitution of an expression itself containing a well-formed defined
operation.

Signed-off-by: John Bowler <jbowler@acm.org>