### PR TITLE
URL updates

### DIFF
--- a/README
+++ b/README
@@ -90,7 +90,7 @@ You may also want a copy of the PNG specification.  It is available
 as an RFC, a W3C Recommendation, and an ISO/IEC Standard.  You can find
 these at http://www.libpng.org/pub/png/documents/
 
-This code is currently being archived at libpng.sf.net in the
+This code is currently being archived at libpng.sourceforge.io in the
 [DOWNLOAD] area, and at ftp://ftp.simplesystems.org.  If you can't find it
 in any of those places, e-mail me, and I'll help you find it.
 

--- a/contrib/arm-neon/android-ndk.c
+++ b/contrib/arm-neon/android-ndk.c
@@ -17,7 +17,7 @@
  *
  * Documentation:
  *    http://www.kandroid.org/ndk/docs/CPU-ARM-NEON.html
- *    http://code.google.com/p/android/issues/detail?id=49065
+ *    https://code.google.com/p/android/issues/detail?id=49065
  *
  * NOTE: this requires that libpng is built against the Android NDK and linked
  * with an implementation of the Android ARM 'cpu-features' library.  The code

--- a/contrib/gregbook/README
+++ b/contrib/gregbook/README
@@ -55,7 +55,7 @@ mation and links to the latest version of the source code, and Chapters
 13-15 of the book for detailed discussion of the three programs.
 
 Greg Roelofs
-http://pobox.com/~newt/greg_contact.html
+https://pobox.com/~newt/greg_contact.html
 16 March 2008
 
 

--- a/contrib/tools/sRGB.h
+++ b/contrib/tools/sRGB.h
@@ -14,7 +14,7 @@
  * All routines take and return a floating point value in the range
  * 0 to 1.0, doing a calculation according to the sRGB specification
  * (in fact the source of the numbers is the wikipedia article at
- * http://en.wikipedia.org/wiki/SRGB).
+ * https://en.wikipedia.org/wiki/SRGB).
  */
 static double
 sRGB_from_linear(double l)

--- a/libpng-manual.txt
+++ b/libpng-manual.txt
@@ -66,17 +66,17 @@ file format in application programs.
 
 The PNG specification (second edition), November 2003, is available as
 a W3C Recommendation and as an ISO Standard (ISO/IEC 15948:2004 (E)) at
-<http://www.w3.org/TR/2003/REC-PNG-20031110/
+<https://www.w3.org/TR/2003/REC-PNG-20031110/
 The W3C and ISO documents have identical technical content.
 
 The PNG-1.2 specification is available at
-<http://png-mng.sourceforge.net/pub/png/spec/1.2/>.
+<https://png-mng.sourceforge.io/pub/png/spec/1.2/>.
 It is technically equivalent
 to the PNG specification (second edition) but has some additional material.
 
-The PNG-1.0 specification is available as RFC 2083 
-<http://png-mng.sourceforge.net/pub/png/spec/1.0/> and as a
-W3C Recommendation <http://www.w3.org/TR/REC-png-961001>.
+The PNG-1.0 specification is available as RFC 2083
+<https://png-mng.sourceforge.io/pub/png/spec/1.0/> and as a
+W3C Recommendation <https://www.w3.org/TR/REC-png-961001>.
 
 Some additional chunks are described in the special-purpose public chunks
 documents at <http://www.libpng.org/pub/png/spec/register/>
@@ -3824,7 +3824,7 @@ PNG_FORMAT_FLAG_LINEAR flag below.
 
 When the simplified API needs to convert between sRGB and linear colorspaces,
 the actual sRGB transfer curve defined in the sRGB specification (see the
-article at http://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
+article at https://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
 approximation used elsewhere in libpng.
 
 When an alpha channel is present it is expected to denote pixel coverage
@@ -4088,7 +4088,7 @@ READ APIs
 
 When the simplified API needs to convert between sRGB and linear colorspaces,
 the actual sRGB transfer curve defined in the sRGB specification (see the
-article at http://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
+article at https://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
 approximation used elsewhere in libpng.
 
 WRITE APIS
@@ -4269,7 +4269,7 @@ However, there are some uncertainties about the status of local variables
 after a longjmp, so the user may want to be careful about doing anything
 after setjmp returns non-zero besides returning itself.  Consult your
 compiler documentation for more details.  For an alternative approach, you
-may wish to use the "cexcept" facility (see http://cexcept.sourceforge.net),
+may wish to use the "cexcept" facility (see https://cexcept.sourceforge.io/),
 which is illustrated in pngvalid.c and in contrib/visupng.
 
 Beginning in libpng-1.4.0, the png_set_benign_errors() API became available.
@@ -4497,7 +4497,7 @@ in a MNG datastream.  As a minimum, it must have the MNG 8-byte signature
 and the MHDR and MEND chunks.  Libpng does not provide support for these
 or any other MNG chunks; your application must provide its own support for
 them.  You may wish to consider using libmng (available at
-http://www.libmng.com) instead.
+https://www.libmng.com/) instead.
 
 VIII.  Changes to Libpng from version 0.88
 
@@ -5197,7 +5197,7 @@ control.  The git repository was built from old libpng-x.y.z.tar.gz files
 going back to version 0.70.  You can access the git repository (read only)
 at
 
-    git://git.code.sf.net/p/libpng/code
+    https://git.code.sf.net/p/libpng/code.git
 
 or you can browse it with a web browser by selecting the "code" button at
 
@@ -5207,7 +5207,7 @@ Patches can be sent to glennrp at users.sourceforge.net or to
 png-mng-implement at lists.sourceforge.net or you can upload them to
 the libpng bug tracker at
 
-    http://libpng.sourceforge.net
+    https://libpng.sourceforge.io/
 
 We also accept patches built from the tar or zip distributions, and
 simple verbal discriptions of bug fixes, reported either to the
@@ -5217,7 +5217,7 @@ mailing list, or directly to glennrp.
 XV. Coding style
 
 Our coding style is similar to the "Allman" style
-(See http://en.wikipedia.org/wiki/Indent_style#Allman_style), with curly
+(See https://en.wikipedia.org/wiki/Indent_style#Allman_style), with curly
 braces on separate lines:
 
     if (condition)
@@ -5318,7 +5318,7 @@ Prior to libpng-1.6.0 we used a "png_sizeof()" macro, formatted as
 though it were a function.
 
 Control keywords if, for, while, and switch are always followed by a space
-to distinguish them from function calls, which have no trailing space. 
+to distinguish them from function calls, which have no trailing space.
 
 We put a space after each comma and after each semicolon
 in "for" statements, and we put spaces before and after each
@@ -5344,7 +5344,7 @@ for a few type names that we inherit from zlib.h.
 
 We prefer "if (something != 0)" and "if (something == 0)" over
 "if (something)" and if "(!something)", respectively, and for pointers
-we prefer "if (some_pointer != NULL)" or "if (some_pointer == NULL)". 
+we prefer "if (some_pointer != NULL)" or "if (some_pointer == NULL)".
 
 We do not use the TAB character for indentation in the C sources.
 

--- a/libpng.3
+++ b/libpng.3
@@ -576,17 +576,17 @@ file format in application programs.
 
 The PNG specification (second edition), November 2003, is available as
 a W3C Recommendation and as an ISO Standard (ISO/IEC 15948:2004 (E)) at
-<http://www.w3.org/TR/2003/REC-PNG-20031110/
+<https://www.w3.org/TR/2003/REC-PNG-20031110/
 The W3C and ISO documents have identical technical content.
 
 The PNG-1.2 specification is available at
-<http://png-mng.sourceforge.net/pub/png/spec/1.2/>.
+<https://png-mng.sourceforge.io/pub/png/spec/1.2/>.
 It is technically equivalent
 to the PNG specification (second edition) but has some additional material.
 
-The PNG-1.0 specification is available as RFC 2083 
-<http://png-mng.sourceforge.net/pub/png/spec/1.0/> and as a
-W3C Recommendation <http://www.w3.org/TR/REC-png-961001>.
+The PNG-1.0 specification is available as RFC 2083
+<https://png-mng.sourceforge.io/pub/png/spec/1.0/> and as a
+W3C Recommendation <https://www.w3.org/TR/REC-png-961001>.
 
 Some additional chunks are described in the special-purpose public chunks
 documents at <http://www.libpng.org/pub/png/spec/register/>
@@ -4334,7 +4334,7 @@ PNG_FORMAT_FLAG_LINEAR flag below.
 
 When the simplified API needs to convert between sRGB and linear colorspaces,
 the actual sRGB transfer curve defined in the sRGB specification (see the
-article at http://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
+article at https://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
 approximation used elsewhere in libpng.
 
 When an alpha channel is present it is expected to denote pixel coverage
@@ -4598,7 +4598,7 @@ READ APIs
 
 When the simplified API needs to convert between sRGB and linear colorspaces,
 the actual sRGB transfer curve defined in the sRGB specification (see the
-article at http://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
+article at https://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
 approximation used elsewhere in libpng.
 
 WRITE APIS
@@ -4779,7 +4779,7 @@ However, there are some uncertainties about the status of local variables
 after a longjmp, so the user may want to be careful about doing anything
 after setjmp returns non-zero besides returning itself.  Consult your
 compiler documentation for more details.  For an alternative approach, you
-may wish to use the "cexcept" facility (see http://cexcept.sourceforge.net),
+may wish to use the "cexcept" facility (see https://cexcept.sourceforge.io/),
 which is illustrated in pngvalid.c and in contrib/visupng.
 
 Beginning in libpng-1.4.0, the png_set_benign_errors() API became available.
@@ -5007,7 +5007,7 @@ in a MNG datastream.  As a minimum, it must have the MNG 8-byte signature
 and the MHDR and MEND chunks.  Libpng does not provide support for these
 or any other MNG chunks; your application must provide its own support for
 them.  You may wish to consider using libmng (available at
-http://www.libmng.com) instead.
+https://www.libmng.com/) instead.
 
 .SH VIII.  Changes to Libpng from version 0.88
 
@@ -5707,7 +5707,7 @@ control.  The git repository was built from old libpng-x.y.z.tar.gz files
 going back to version 0.70.  You can access the git repository (read only)
 at
 
-    git://git.code.sf.net/p/libpng/code
+    https://git.code.sf.net/p/libpng/code.git
 
 or you can browse it with a web browser by selecting the "code" button at
 
@@ -5717,7 +5717,7 @@ Patches can be sent to glennrp at users.sourceforge.net or to
 png-mng-implement at lists.sourceforge.net or you can upload them to
 the libpng bug tracker at
 
-    http://libpng.sourceforge.net
+    https://libpng.sourceforge.io/
 
 We also accept patches built from the tar or zip distributions, and
 simple verbal discriptions of bug fixes, reported either to the
@@ -5727,7 +5727,7 @@ mailing list, or directly to glennrp.
 .SH XV. Coding style
 
 Our coding style is similar to the "Allman" style
-(See http://en.wikipedia.org/wiki/Indent_style#Allman_style), with curly
+(See https://en.wikipedia.org/wiki/Indent_style#Allman_style), with curly
 braces on separate lines:
 
     if (condition)
@@ -5828,7 +5828,7 @@ Prior to libpng-1.6.0 we used a "png_sizeof()" macro, formatted as
 though it were a function.
 
 Control keywords if, for, while, and switch are always followed by a space
-to distinguish them from function calls, which have no trailing space. 
+to distinguish them from function calls, which have no trailing space.
 
 We put a space after each comma and after each semicolon
 in "for" statements, and we put spaces before and after each
@@ -5854,7 +5854,7 @@ for a few type names that we inherit from zlib.h.
 
 We prefer "if (something != 0)" and "if (something == 0)" over
 "if (something)" and if "(!something)", respectively, and for pointers
-we prefer "if (some_pointer != NULL)" or "if (some_pointer == NULL)". 
+we prefer "if (some_pointer != NULL)" or "if (some_pointer == NULL)".
 
 We do not use the TAB character for indentation in the C sources.
 
@@ -5987,7 +5987,7 @@ release number plus "betaNN" or "rcNN".
 .LP
 .IR libpng :
 .IP
-http://libpng.sourceforge.net (follow the [DOWNLOAD] link)
+https://libpng.sourceforge.io/ (follow the [DOWNLOAD] link)
 http://www.libpng.org/pub/png
 
 .LP
@@ -5997,7 +5997,7 @@ http://www.libpng.org/pub/png
 .I libpng
 or at
 .br
-ftp://ftp.info-zip.org/pub/infozip/zlib
+http://zlib.net/
 
 .LP
 .IR PNG specification: RFC 2083
@@ -6006,11 +6006,11 @@ ftp://ftp.info-zip.org/pub/infozip/zlib
 .I libpng
 or at
 .br
-ftp://ftp.rfc-editor.org:/in-notes/rfc2083.txt
+https://www.ietf.org/rfc/rfc2083.txt
 .br
 or (as a W3C Recommendation) at
 .br
-http://www.w3.org/TR/REC-png.html
+https://www.w3.org/TR/REC-png.html
 
 .LP
 In the case of any inconsistency between the PNG specification

--- a/png.5
+++ b/png.5
@@ -23,11 +23,11 @@ platforms.
 PNG specification (second edition), November 2003:
 .IP
 .br
-  <http://www.w3.org/TR/2003/REC-PNG-20031110/
+  <https://www.w3.org/TR/2003/REC-PNG-20031110/
 PNG 1.2 specification, July 1999:
 .IP
 .br
-http://png-mng.sourceforge.net/pub/png/spec/1.2/
+https://png-mng.sourceforge.io/pub/png/spec/1.2/
 .LP
 PNG 1.0 specification, October 1996:
 .IP
@@ -35,11 +35,11 @@ PNG 1.0 specification, October 1996:
 RFC 2083
 .IP
 .br
-http://www.ietf.org/rfc/rfc2083.txt
+https://www.ietf.org/rfc/rfc2083.txt
 .br
 or (as a W3C Recommendation) at
 .br
-http://www.w3.org/TR/REC-png-961001
+https://www.w3.org/TR/REC-png-961001
 .SH AUTHORS
 This man page: Glenn Randers-Pehrson
 .LP

--- a/png.c
+++ b/png.c
@@ -4295,7 +4295,7 @@ png_set_option(png_structrp png_ptr, int option, int onoff)
    defined(PNG_SIMPLIFIED_WRITE_SUPPORTED)
 /* sRGB conversion tables; these are machine generated with the code in
  * contrib/tools/makesRGB.c.  The actual sRGB transfer curve defined in the
- * specification (see the article at http://en.wikipedia.org/wiki/SRGB)
+ * specification (see the article at https://en.wikipedia.org/wiki/SRGB)
  * is used, not the gamma=1/2.2 approximation use elsewhere in libpng.
  * The sRGB to linear table is exact (to the nearest 16-bit linear fraction).
  * The inverse (linear to sRGB) table has accuracies as follows:

--- a/png.h
+++ b/png.h
@@ -234,7 +234,7 @@
  *
  * See libpng.txt or libpng.3 for more information.  The PNG specification
  * is available as a W3C Recommendation and as an ISO Specification,
- * <http://www.w3.org/TR/2003/REC-PNG-20031110/
+ * <https://www.w3.org/TR/2003/REC-PNG-20031110/
  */
 
 /*
@@ -2753,7 +2753,7 @@ typedef struct
  *
  * When the simplified API needs to convert between sRGB and linear colorspaces,
  * the actual sRGB transfer curve defined in the sRGB specification (see the
- * article at http://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
+ * article at https://en.wikipedia.org/wiki/SRGB) is used, not the gamma=1/2.2
  * approximation used elsewhere in libpng.
  *
  * When an alpha channel is present it is expected to denote pixel coverage

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -2934,7 +2934,7 @@ png_do_gray_to_rgb(png_row_infop row_info, png_bytep row)
  * using the equation given in Poynton's ColorFAQ of 1998-01-04 at
  * <http://www.inforamp.net/~poynton/>  (THIS LINK IS DEAD June 2008 but
  * versions dated 1998 through November 2002 have been archived at
- * http://web.archive.org/web/20000816232553/http://www.inforamp.net/
+ * https://web.archive.org/web/20000816232553/www.inforamp.net/
  * ~poynton/notes/colour_and_gamma/ColorFAQ.txt )
  * Charles Poynton poynton at poynton.com
  *

--- a/projects/owatcom/pngconfig.mak
+++ b/projects/owatcom/pngconfig.mak
@@ -126,7 +126,7 @@ $# to work, download Brian Kernighan's awk (Brian Kernighan is the author of
 $# awk.)  You can find source code and a built executable (called awk95.exe)
 $# here:
 $#
-$#     http://www.cs.princeton.edu/~bwk/btl.mirror/
+$#     https://www.cs.princeton.edu/~bwk/btl.mirror/
 $#
 $# The executable works just fine.
 $#


### PR DESCRIPTION
It'd be nice to enable HTTPS on the SourceForge website of `libpng`, as described here:
https://sourceforge.net/blog/introducing-https-for-project-websites/
