### PR TITLE
CMakeLists.txt: Enable building asm code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ endif(POLICY CMP0054)
 
 set(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
 
-project(libpng C)
+project(libpng ASM C)
 enable_testing()
 
 set(PNGLIB_MAJOR 1)


### PR DESCRIPTION
NEON support is provided by filter_neon.S which is currently not build
by cmake causing an error when linking with libpng16.so.16.32.0:

[ 97%] Linking C executable pngstest
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_avg4_neon'
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_paeth3_neon'
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_up_neon'
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_avg3_neon'
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_paeth4_neon'
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_sub4_neon'
libpng16.so.16.32.0: undefined reference to `png_read_filter_row_sub3_neon'