### PR TITLE
Misc. typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1454,7 +1454,7 @@ Version 1.2.6beta4 [July 28, 2004]
     sequential read support.
   Added some "#if PNG_WRITE_SUPPORTED" blocks.
   Added #ifdef to remove some redundancy in png_malloc_default().
-  Use png_malloc instead of png_zalloc to allocate the pallete.
+  Use png_malloc instead of png_zalloc to allocate the palette.
 
 Version 1.0.16rc1 and 1.2.6rc1 [August 4, 2004]
   Fixed buffer overflow vulnerability (CVE-2004-0597) in png_handle_tRNS().
@@ -3359,7 +3359,7 @@ Version 1.5.3beta05 [May 6, 2011]
   Pass "" instead of '\0' to png_default_error() in png_err().  This mistake
     was introduced in libpng-1.2.20beta01.  This fixes CVE-2011-2691.
   Added PNG_WRITE_OPTIMIZE_CMF_SUPPORTED macro to make the zlib "CMF" byte
-    optimization configureable.
+    optimization configurable.
   IDAT compression failed if preceded by a compressed text chunk (bug
     introduced in libpng-1.5.3beta01-02).  This was because the attempt to
     reset the zlib stream in png_write_IDAT happened after the first IDAT
@@ -3735,7 +3735,7 @@ Version 1.5.7beta03 [November 17, 2011]
     gray (on palette) itself.
   Fixes for C++ compilation using g++ When libpng source is compiled
     using g++. The compiler imposes C++ rules on the C source; thus it
-    is desireable to make the source work with either C or C++ rules
+    is desirable to make the source work with either C or C++ rules
     without throwing away useful error information.  This change adds
     png_voidcast to allow C semantic (void*) cases or the corresponding
     C++ static_cast operation, as appropriate.
@@ -4061,7 +4061,7 @@ Version 1.6.0beta17 [March 10, 2012]
     possible to call png_inflate() incrementally.  A warning is no longer
     issued if the language tag or translated keyword in the iTXt chunk
     has zero length.
-  If benign errors are disabled use maximum window on ancilliary inflate.
+  If benign errors are disabled use maximum window on ancillary inflate.
     This works round a bug introduced in 1.5.4 where compressed ancillary
     chunks could end up with a too-small windowBits value in the deflate
     header.
@@ -4309,7 +4309,7 @@ Version 1.6.0beta31 [November 1, 2012]
     resulting in VS2010 having to update the files.
   Removed non-working ICC profile support code that was mostly added to
     libpng-1.6.0beta29 and beta30. There was too much code for too little
-    gain; implementing full ICC color correction may be desireable but is left
+    gain; implementing full ICC color correction may be desirable but is left
     up to applications.
 
 Version 1.6.0beta32 [November 25, 2012]
@@ -4592,7 +4592,7 @@ Version 1.6.3beta07 [June 8, 2013]
     the optimizations ('check' vs 'api') are exposed in the public header files
     except that the new setting PNG_ARM_NEON_OPT documents how libpng makes the
     decision about whether or not to use the optimizations.
-  Protect symbol prefixing against CC/CPPFLAGS/CFLAGS useage.
+  Protect symbol prefixing against CC/CPPFLAGS/CFLAGS usage.
     Previous iOS/Xcode fixes for the ARM NEON optimizations moved the test
     on __ARM_NEON__ from configure time to compile time.  This breaks symbol
     prefixing because the definition of the special png_init_filter_functions
@@ -5635,7 +5635,7 @@ Version 1.6.24beta02 [June 23, 2016]
     to All and adds a list of the warnings that need to be turned off.  This is
     semi-documentary; the intent is to tell libpng users which warnings have
     been examined and judged non-fixable at present.  The warning about
-    structure padding is fixable, but it would be a signficant change (moving
+    structure padding is fixable, but it would be a significant change (moving
     structure members around).
 
 Version 1.6.24beta03 [July 4, 2016]
@@ -5781,7 +5781,7 @@ Version 1.6.28rc01 [January 3, 2017]
   Added option to Cmake build allowing a custom location of zlib to be
     specified in a scenario where libpng is being built as a subproject
     alongside zlib by another project (Sam Serrels).
-  Changed png_ptr->options from a png_byte to png_uint_32, to accomodate
+  Changed png_ptr->options from a png_byte to png_uint_32, to accommodate
     up to 16 options.
 
 Version 1.6.28rc02 [January 4, 2017]
@@ -5932,7 +5932,7 @@ Version 1.6.32beta04 [August 2, 2017]
   Update libpng.3 and libpng-manual.txt about eXIf functions.
 
 Version 1.6.32beta05 [August 2, 2017]
-  Restored png_get_eXIf() and png_set_eXIf() to maintain API compatability.
+  Restored png_get_eXIf() and png_set_eXIf() to maintain API compatibility.
 
 Version 1.6.32beta06 [August 2, 2017]
   Removed png_get_eXIf_1() and png_set_eXIf_1().

--- a/autogen.sh
+++ b/autogen.sh
@@ -194,7 +194,7 @@ case "$mode" in
       if test -d .git
       then
          exec >&2
-         echo "ERROR: running autoreconf on an initialized sytem"
+         echo "ERROR: running autoreconf on an initialized system"
          echo "  This is not necessary; it is only necessary to remake the"
          echo "  autotools generated files if Makefile.am or configure.ac"
          echo "  change and make does the right thing with:"

--- a/contrib/examples/iccfrompng.c
+++ b/contrib/examples/iccfrompng.c
@@ -10,7 +10,7 @@
  * without processing the image.  Notice that some header information may occur
  * after the image data. Textual data and comments are an example; the approach
  * in this file won't work reliably for such data because it only looks for the
- * information in the section of the file that preceeds the image data.
+ * information in the section of the file that precedes the image data.
  *
  * Compile and link against libpng and zlib, plus anything else required on the
  * system you use.

--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -927,7 +927,7 @@ update_display(struct display *dp)
    png_structp pp;
    png_infop   ip;
 
-   /* Now perform the initial read with a 0 tranform. */
+   /* Now perform the initial read with a 0 transform. */
    read_png(dp, &dp->original_file, "original read", 0/*no transform*/);
 
    /* Move the result to the 'original' fields */

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -1142,7 +1142,7 @@ get_pixel(png_uint_32 format))(Pixel *p, png_const_voidp pb)
    }
 }
 
-/* Convertion between pixel formats.  The code above effectively eliminates the
+/* Conversion between pixel formats.  The code above effectively eliminates the
  * component ordering changes leaving three basic changes:
  *
  * 1) Remove an alpha channel by pre-multiplication or compositing on a

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -5001,7 +5001,7 @@ standard_display_init(standard_display *dp, png_store* ps, png_uint_32 id,
    dp->npalette = 0;
    /* Preset the transparent color to black: */
    memset(&dp->transparent, 0, sizeof dp->transparent);
-   /* Preset the palette to full intensity/opaque througout: */
+   /* Preset the palette to full intensity/opaque throughout: */
    memset(dp->palette, 0xff, sizeof dp->palette);
 }
 
@@ -9746,7 +9746,7 @@ gamma_component_validate(const char *name, const validate_info *vi,
        *
        * pngvalid calculations:
        *  input_sample: linear result; i linearized and composed, range 0..1
-       *  encoded_sample: encoded result; input_sample scaled to ouput bit depth
+       *  encoded_sample: encoded result; input_sample scaled to output bit depth
        *
        * libpng calculations:
        *  output: linear result; od scaled to 0..1 and linearized
@@ -10183,10 +10183,10 @@ gamma_image_validate(gamma_display *dp, png_const_structp pp,
     * Since the library must quantize the output to 8 or 16 bits there is
     * a fundamental limit on the accuracy of the output of +/-.5 - this
     * quantization limit is included in addition to the other limits
-    * specified by the paramaters to the API.  (Effectively, add .5
+    * specified by the parameters to the API.  (Effectively, add .5
     * everywhere.)
     *
-    * The behavior of the 'sbit' paramter is defined by section 12.5
+    * The behavior of the 'sbit' parameter is defined by section 12.5
     * (sample depth scaling) of the PNG spec.  That section forces the
     * decoder to assume that the PNG values have been scaled if sBIT is
     * present:
@@ -11729,7 +11729,7 @@ int main(int argc, char **argv)
 
    /* Some default values (set the behavior for 'make check' here).
     * These values simply control the maximum error permitted in the gamma
-    * transformations.  The practial limits for human perception are described
+    * transformations.  The practical limits for human perception are described
     * below (the setting for maxpc16), however for 8 bit encodings it isn't
     * possible to meet the accepted capabilities of human vision - i.e. 8 bit
     * images can never be good enough, regardless of encoding.

--- a/contrib/libtests/tarith.c
+++ b/contrib/libtests/tarith.c
@@ -176,7 +176,7 @@ int validation_ascii_to_fp(int count, int argc, char **argv)
       }
       else if (PNG_FP_IS_POSITIVE(state) && !(test > 0))
       {
-         fprintf(stderr, "%g[%d] -> '%s' but postive value not so reported\n",
+         fprintf(stderr, "%g[%d] -> '%s' but positive value not so reported\n",
             test, precision, buffer);
          failed = 1;
          assert(!PNG_FP_IS_NEGATIVE(state));

--- a/contrib/pngminus/README
+++ b/contrib/pngminus/README
@@ -17,7 +17,7 @@ express or implied warranty.
 Some history
 ------------
 Soon after the creation of PNG in 1995, the need was felt for a set of
-pnmtopng / pngtopnm utilities. Independantly Alexander Lehmann and I
+pnmtopng / pngtopnm utilities. Independently Alexander Lehmann and I
 (Willem van Schaik) started such a project. Luckily we discovered this
 and merged the two together into pnmtopng.tar.gz, which is available
 from a/o ftp://ftp.simplesystems.org/pub/libpng/png/.

--- a/contrib/tools/pngcp.c
+++ b/contrib/tools/pngcp.c
@@ -2117,7 +2117,7 @@ better_options(const struct display *dp)
     *
     * This function looks through the stack from the bottom up looking for an
     * option that does not match the current best value.  When it finds one it
-    * checks to see if it is more or less desireable and returns true or false
+    * checks to see if it is more or less desirable and returns true or false
     * as appropriate.
     *
     * Notice that this means that the order options are pushed onto the stack

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -2664,7 +2664,7 @@ zlib_check(struct file *file, png_uint_32 offset)
              * this case, so do the optimization anyway.
              */
             if (zlib.cksum)
-               chunk_message(zlib.chunk, "zlib checkum");
+               chunk_message(zlib.chunk, "zlib checksum");
             break;
 
 
@@ -3678,7 +3678,7 @@ usage(const char *prog)
    size_t i;
    static const char *usage_string[] = {
 "  Tests, optimizes and optionally fixes the zlib header in PNG files.",
-"  Optionally, when fixing, strips ancilliary chunks from the file.",
+"  Optionally, when fixing, strips ancillary chunks from the file.",
 0,
 "OPTIONS",
 "  OPERATION",

--- a/contrib/visupng/VisualPng.c
+++ b/contrib/visupng/VisualPng.c
@@ -716,7 +716,7 @@ BOOL DisplayImage (HWND hwnd, BYTE **ppDib,
     png_color                   bkgGray  = {127, 127, 127};
     png_color                   bkgWhite = {255, 255, 255};
 
-    /* allocate memory for the Device Independant bitmap */
+    /* allocate memory for the Device Independent bitmap */
 
     wDIRowBytes = (WORD) ((3 * cxWinSize + 3L) >> 2) << 2;
 

--- a/libpng-manual.txt
+++ b/libpng-manual.txt
@@ -1003,7 +1003,7 @@ chunks to be assumed to be encoded using sRGB.
     png_set_alpha_mode(pp, PNG_ALPHA_PNG, PNG_GAMMA_MAC);
 
 In this case the output is assumed to be something like an sRGB conformant
-display preceeded by a power-law lookup table of power 1.45.  This is how
+display preceded by a power-law lookup table of power 1.45.  This is how
 early Mac systems behaved.
 
     png_set_alpha_mode(pp, PNG_ALPHA_STANDARD, PNG_GAMMA_LINEAR);
@@ -1055,7 +1055,7 @@ faster.)
 
 When the default gamma of PNG files doesn't match the output gamma.
 If you have PNG files with no gamma information png_set_alpha_mode allows
-you to provide a default gamma, but it also sets the ouput gamma to the
+you to provide a default gamma, but it also sets the output gamma to the
 matching value.  If you know your PNG files have a gamma that doesn't
 match the output you can take advantage of the fact that
 png_set_alpha_mode always sets the output gamma but only sets the PNG
@@ -3779,7 +3779,7 @@ in-memory bitmap formats or to be written from the same formats.  If these
 formats do not accommodate your needs then you can, and should, use the more
 sophisticated APIs above - these support a wide variety of in-memory formats
 and a wide variety of sophisticated transformations to those formats as well
-as a wide variety of APIs to manipulate ancilliary information.
+as a wide variety of APIs to manipulate ancillary information.
 
 To read a PNG file using the simplified API:
 

--- a/libpng.3
+++ b/libpng.3
@@ -1521,7 +1521,7 @@ chunks to be assumed to be encoded using sRGB.
     png_set_alpha_mode(pp, PNG_ALPHA_PNG, PNG_GAMMA_MAC);
 
 In this case the output is assumed to be something like an sRGB conformant
-display preceeded by a power-law lookup table of power 1.45.  This is how
+display preceded by a power-law lookup table of power 1.45.  This is how
 early Mac systems behaved.
 
     png_set_alpha_mode(pp, PNG_ALPHA_STANDARD, PNG_GAMMA_LINEAR);
@@ -1573,7 +1573,7 @@ faster.)
 
 When the default gamma of PNG files doesn't match the output gamma.
 If you have PNG files with no gamma information png_set_alpha_mode allows
-you to provide a default gamma, but it also sets the ouput gamma to the
+you to provide a default gamma, but it also sets the output gamma to the
 matching value.  If you know your PNG files have a gamma that doesn't
 match the output you can take advantage of the fact that
 png_set_alpha_mode always sets the output gamma but only sets the PNG
@@ -4297,7 +4297,7 @@ in-memory bitmap formats or to be written from the same formats.  If these
 formats do not accommodate your needs then you can, and should, use the more
 sophisticated APIs above - these support a wide variety of in-memory formats
 and a wide variety of sophisticated transformations to those formats as well
-as a wide variety of APIs to manipulate ancilliary information.
+as a wide variety of APIs to manipulate ancillary information.
 
 To read a PNG file using the simplified API:
 

--- a/png.c
+++ b/png.c
@@ -942,7 +942,7 @@ png_handle_as_unknown(png_const_structrp png_ptr, png_const_bytep chunk_name)
 
    /* The code is the fifth byte after each four byte string.  Historically this
     * code was always searched from the end of the list, this is no longer
-    * necessary because the 'set' routine handles duplicate entries correcty.
+    * necessary because the 'set' routine handles duplicate entries correctly.
     */
    do /* num_chunk_list > 0, so at least one */
    {
@@ -2067,7 +2067,7 @@ png_icc_check_header(png_const_structrp png_ptr, png_colorspacerp colorspace,
     */
 
    /* Data checks (could be skipped).  These checks must be independent of the
-    * version number; however, the version number doesn't accomodate changes in
+    * version number; however, the version number doesn't accommodate changes in
     * the header fields (just the known tags and the interpretation of the
     * data.)
     */
@@ -2707,7 +2707,7 @@ png_check_IHDR(png_const_structrp png_ptr,
 
 #if defined(PNG_sCAL_SUPPORTED) || defined(PNG_pCAL_SUPPORTED)
 /* ASCII to fp functions */
-/* Check an ASCII formated floating point value, see the more detailed
+/* Check an ASCII formatted floating point value, see the more detailed
  * comments in pngpriv.h
  */
 /* The following is used internally to preserve the sticky flags */

--- a/png.h
+++ b/png.h
@@ -1193,7 +1193,7 @@ PNG_FIXED_EXPORT(228, void, png_set_alpha_mode_fixed, (png_structrp png_ptr,
  *
  * png_set_alpha_mode(pp, PNG_ALPHA_PNG, PNG_GAMMA_MAC);
  *    In this case the output is assumed to be something like an sRGB conformant
- *    display preceeded by a power-law lookup table of power 1.45.  This is how
+ *    display preceded by a power-law lookup table of power 1.45.  This is how
  *    early Mac systems behaved.
  *
  * png_set_alpha_mode(pp, PNG_ALPHA_STANDARD, PNG_GAMMA_LINEAR);
@@ -1240,7 +1240,7 @@ PNG_FIXED_EXPORT(228, void, png_set_alpha_mode_fixed, (png_structrp png_ptr,
  *
  * When the default gamma of PNG files doesn't match the output gamma.
  *    If you have PNG files with no gamma information png_set_alpha_mode allows
- *    you to provide a default gamma, but it also sets the ouput gamma to the
+ *    you to provide a default gamma, but it also sets the output gamma to the
  *    matching value.  If you know your PNG files have a gamma that doesn't
  *    match the output you can take advantage of the fact that
  *    png_set_alpha_mode always sets the output gamma but only sets the PNG
@@ -1691,7 +1691,7 @@ PNG_EXPORT(218, png_byte, png_get_current_pass_number, (png_const_structrp));
  *           chunk will cause an error at this point unless it is to be saved.
  * positive: The chunk was handled, libpng will ignore/discard it.
  *
- * See "INTERACTION WTIH USER CHUNK CALLBACKS" below for important notes about
+ * See "INTERACTION WITH USER CHUNK CALLBACKS" below for important notes about
  * how this behavior will change in libpng 1.7
  */
 PNG_EXPORT(88, void, png_set_read_user_chunk_fn, (png_structrp png_ptr,
@@ -2239,7 +2239,7 @@ PNG_EXPORT(171, void, png_set_sCAL_s, (png_const_structrp png_ptr,
  * to specifying "NEVER", however when "AS_DEFAULT" is used for specific chunks
  * it simply resets the behavior to the libpng default.
  *
- * INTERACTION WTIH USER CHUNK CALLBACKS:
+ * INTERACTION WITH USER CHUNK CALLBACKS:
  * The per-chunk handling is always used when there is a png_user_chunk_ptr
  * callback and the callback returns 0; the chunk is then always stored *unless*
  * it is critical and the per-chunk setting is other than ALWAYS.  Notice that
@@ -2658,7 +2658,7 @@ PNG_EXPORT(243, int, png_get_palette_max, (png_const_structp png_ptr,
  * The simplified API hides the details of both libpng and the PNG file format
  * itself.  It allows PNG files to be read into a very limited number of
  * in-memory bitmap formats or to be written from the same formats.  If these
- * formats do not accomodate your needs then you can, and should, use the more
+ * formats do not accommodate your needs then you can, and should, use the more
  * sophisticated APIs above - these support a wide variety of in-memory formats
  * and a wide variety of sophisticated transformations to those formats as well
  * as a wide variety of APIs to manipulate ancillary information.
@@ -3133,7 +3133,7 @@ PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
     * than or equal to the original value.
     *
     * If the function returns false and *memory_bytes was not changed an error
-    * occured during write.  If *memory_bytes was changed, or is not 0 if
+    * occurred during write.  If *memory_bytes was changed, or is not 0 if
     * 'memory' was NULL, the write would have succeeded but for the memory
     * buffer being too small.  *memory_bytes contains the required number of
     * bytes and will be bigger that the original value.

--- a/pngconf.h
+++ b/pngconf.h
@@ -127,7 +127,7 @@
  *
  * These cases only differ if the operating system does not use the C
  * calling convention, at present this just means the above cases
- * (x86 DOS/Windows sytems) and, even then, this does not apply to
+ * (x86 DOS/Windows systems) and, even then, this does not apply to
  * Cygwin running on those systems.
  *
  * Note that the value must be defined in pnglibconf.h so that what

--- a/pnginfo.h
+++ b/pnginfo.h
@@ -247,7 +247,7 @@ defined(PNG_READ_BACKGROUND_SUPPORTED)
    /* The sCAL chunk describes the actual physical dimensions of the
     * subject matter of the graphic.  The chunk contains a unit specification
     * a byte value, and two ASCII strings representing floating-point
-    * values.  The values are width and height corresponsing to one pixel
+    * values.  The values are width and height corresponding to one pixel
     * in the image.  Data values are valid if (valid & PNG_INFO_sCAL) is
     * non-zero.
     */

--- a/pngread.c
+++ b/pngread.c
@@ -4150,7 +4150,7 @@ png_image_finish_read(png_imagep image, png_const_colorp background,
              *
              * NOTE: this will be changed in 1.7 because PNG_IMAGE_BUFFER_SIZE
              * will be changed to use png_alloc_size_t; bigger images can be
-             * accomodated on 64-bit systems.
+             * accommodated on 64-bit systems.
              */
             if (image->height <=
                 0xffffffffU/PNG_IMAGE_PIXEL_COMPONENT_SIZE(image->format)/check)

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -292,7 +292,7 @@ png_set_alpha_mode_fixed(png_structrp png_ptr, int mode,
     * who use the inverse of the gamma value accidentally!  Since some of these
     * values are reasonable this may have to be changed:
     *
-    * 1.6.x: changed from 0.07..3 to 0.01..100 (to accomodate the optimal 16-bit
+    * 1.6.x: changed from 0.07..3 to 0.01..100 (to accommodate the optimal 16-bit
     * gamma of 36, and its reciprocal.)
     */
    if (output_gamma < 1000 || output_gamma > 10000000)
@@ -1317,7 +1317,7 @@ png_init_read_transformations(png_structrp png_ptr)
 
       else if (png_ptr->screen_gamma != 0)
          /* The converse - assume the file matches the screen, note that this
-          * perhaps undesireable default can (from 1.5.4) be changed by calling
+          * perhaps undesirable default can (from 1.5.4) be changed by calling
           * png_set_alpha_mode (even if the alpha handling mode isn't required
           * or isn't changed from the default.)
           */
@@ -1885,7 +1885,7 @@ png_init_read_transformations(png_structrp png_ptr)
 
       png_ptr->transformations &= ~PNG_SHIFT;
 
-      /* significant bits can be in the range 1 to 7 for a meaninful result, if
+      /* significant bits can be in the range 1 to 7 for a meaningful result, if
        * the number of significant bits is 0 then no shift is done (this is an
        * error condition which is silently ignored.)
        */

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -102,7 +102,7 @@ png_get_int_32)(png_const_bytep buf)
 png_uint_16 (PNGAPI
 png_get_uint_16)(png_const_bytep buf)
 {
-   /* ANSI-C requires an int value to accomodate at least 16 bits so this
+   /* ANSI-C requires an int value to accommodate at least 16 bits so this
     * works and allows the compiler not to worry about possible narrowing
     * on 32-bit systems.  (Pre-ANSI systems did not make integers smaller
     * than 16 bits either.)

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -47,7 +47,7 @@
 /* zlib.h declares a magic type 'uInt' that limits the amount of data that zlib
  * can handle at once.  This type need be no larger than 16 bits (so maximum of
  * 65535), this define allows us to discover how big it is, but limited by the
- * maximuum for png_size_t.  The value can be overriden in a library build
+ * maximuum for png_size_t.  The value can be overridden in a library build
  * (pngusr.h, or set it in CPPFLAGS) and it works to set it to a considerably
  * lower value (e.g. 255 works).  A lower value may help memory usage (slightly)
  * and may even improve performance on some systems (and degrade it on others.)

--- a/projects/visualc71/README.txt
+++ b/projects/visualc71/README.txt
@@ -12,7 +12,7 @@ Assumptions:
 * The libpng source files are in ..\..
 * The zlib source files are in ..\..\..\zlib
 * The zlib project file is in . /* Warning: This is until the zlib project
-  files get intergrated into the next zlib release. The final zlib project
+  files get integrated into the next zlib release. The final zlib project
   directory will then be ..\..\..\zlib\projects\visualc71. */
 
 To use:

--- a/scripts/options.awk
+++ b/scripts/options.awk
@@ -40,7 +40,7 @@ BEGIN{
    # the lines, for example by inserting spaces around operators, and all
    # C preprocessors notice lines that start with '#', most remove comments.
    # The technique adopted here is to make the final output lines into
-   # C strings (enclosed in double quotes), preceeded by PNG_DFN.  As a
+   # C strings (enclosed in double quotes), preceded by PNG_DFN.  As a
    # consequence the output cannot contain a 'raw' double quote - instead put
    # @' in, this will be replaced by a single " afterward.  See the parser
    # script dfn.awk for more capabilities (not required here).  Note that if
@@ -336,7 +336,7 @@ $1 == "option" && NF >= 2{
 
 # chunk NAME [requires OPT] [enables LIST] [on|off|disabled]
 #   Expands to the 'option' settings appropriate to the reading and
-#   writing of an ancilliary PNG chunk 'NAME':
+#   writing of an ancillary PNG chunk 'NAME':
 #
 #   option READ_NAME requires READ_ANCILLARY_CHUNKS [READ_OPT]
 #   option READ_NAME enables NAME LIST

--- a/scripts/pnglibconf.dfa
+++ b/scripts/pnglibconf.dfa
@@ -324,7 +324,7 @@ option WRITE_INT_FUNCTIONS disabled
 #     By default recoverable errors on write should just generate warnings,
 #     not generally safe because this allows the application to write invalid
 #     PNG files.  Applications should enable this themselves; it's useful
-#     because it means that a failure to write an ancilliary chunk can often be
+#     because it means that a failure to write an ancillary chunk can often be
 #     ignored.
 
 option WARNINGS
@@ -395,7 +395,7 @@ option IO_STATE
 option USER_LIMITS requires READ
 
 # The default settings given below for the limits mean that libpng will
-# limit the size of images or the size of data in ancilliary chunks to less
+# limit the size of images or the size of data in ancillary chunks to less
 # than the specification or implementation limits. Settings have the
 # following interpretations:
 #
@@ -559,7 +559,7 @@ option WRITE_CUSTOMIZE_ZTXT_COMPRESSION requires WRITE
 option WRITE_CUSTOMIZE_COMPRESSION requires WRITE
 
 # Any chunks you are not interested in, you can undef here.  The
-# ones that allocate memory may be expecially important (hIST,
+# ones that allocate memory may be especially important (hIST,
 # tEXt, zTXt, tRNS, pCAL).  Others will just save time and make png_info
 # a bit smaller.
 
@@ -715,7 +715,7 @@ setting sCAL_PRECISION default 5
 setting ZBUF_SIZE default 8192
 
 # This is the size of the decompression buffer used when counting or checking
-# the decompressed size of an LZ stream from a compressed ancilliary chunk; the
+# the decompressed size of an LZ stream from a compressed ancillary chunk; the
 # decompressed data is never used so a different size may be optimal.  This size
 # was determined using contrib/libtests/timepng.c with compressed zTXt data
 # around 11MByte in size.  Slight speed improvements (up to about 14% in


### PR DESCRIPTION
Some are user facing. Some are in actual code. Most are in source comments. Also, please double check the changes in contrib/tools/pngfix.c