### PR TITLE
[libpng15] fix memset in pngrutil.c

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1278,9 +1278,6 @@ PNG_EXTERN void png_check_chunk_length PNGARG((png_structp png_ptr,
 PNG_EXTERN void png_handle_unknown PNGARG((png_structp png_ptr,
     png_infop info_ptr, png_uint_32 length));
 
-PNG_EXTERN void png_check_chunk_name PNGARG((png_structp png_ptr,
-    png_uint_32 chunk_name));
-
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
 /* Exactly as png_handle_as_unknown() except that the argument is a 32-bit chunk
  * name, not a string.

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -471,12 +471,14 @@ png_decompress_chunk(png_structp png_ptr, int comp_type,
       {
          /* Success (maybe) - really uncompress the chunk. */
          png_size_t new_size = 0;
+         png_size_t buffer_size = prefix_size + expanded_size + 1;
          png_charp text = (png_charp)png_malloc_warn(png_ptr,
-             prefix_size + expanded_size + 1);
-         memset(text, 0, prefix_size + expanded_size + 1); /* just in case */
+             buffer_size);
 
          if (text != NULL)
          {
+            memset(text, 0, buffer_size);
+
             png_memcpy(text, png_ptr->chunkdata, prefix_size);
             new_size = png_inflate(png_ptr,
                 (png_bytep)(png_ptr->chunkdata + prefix_size),

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -2674,6 +2674,10 @@ png_handle_unknown(png_structp png_ptr, png_infop info_ptr, png_uint_32 length)
 {
    png_uint_32 skip = 0;
 
+#ifndef PNG_READ_USER_CHUNKS_SUPPORTED
+   PNG_UNUSED(info_ptr) /* Quiet compiler warnings about unused info_ptr */
+#endif
+
    png_debug(1, "in png_handle_unknown");
 
 #ifdef PNG_USER_LIMITS_SUPPORTED
@@ -2787,10 +2791,6 @@ png_handle_unknown(png_structp png_ptr, png_infop info_ptr, png_uint_32 length)
       skip = length;
 
    png_crc_finish(png_ptr, skip);
-
-#ifndef PNG_READ_USER_CHUNKS_SUPPORTED
-   PNG_UNUSED(info_ptr) /* Quiet compiler warnings about unused info_ptr */
-#endif
 }
 
 /* This function is called to verify that a chunk name is valid.


### PR DESCRIPTION
There's a small issue in pngrutil.c that is already fixed in libpng16 branch.
Two warnings fixed too:
```
> pngpriv.h:1281:17: warning: redundant redeclaration of 'png_check_chunk_name' [-Wredundant-decls]
> pngpriv.h:1272:17: note: previous declaration of 'png_check_chunk_name' was here
```