### PR TITLE
Fix png_set_option to work.

### DIFF
--- a/png.c
+++ b/png.c
@@ -4344,7 +4344,7 @@ png_set_option(png_structrp png_ptr, int option, int onoff)
       png_uint_32 setting = (2U + (onoff != 0)) << option;
       png_uint_32 current = png_ptr->options;
 
-      png_ptr->options = (png_uint_32)(((current & ~mask) | setting) & 0xff);
+      png_ptr->options = (png_uint_32)((current & ~mask) | setting);
 
       return (int)(current & mask) >> option;
    }


### PR DESCRIPTION
The type of png_ptr->options has changed from png_byte to png_uint_32, therefore '& 0xFF' is undesired.