### PR TITLE
libpng.pc.in: zlib dependency is private

### DIFF
--- a/libpng.pc.in
+++ b/libpng.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@/libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@
 Name: libpng
 Description: Loads and saves PNG files
 Version: @PNGLIB_VERSION@
-Requires: zlib
+Requires.private: zlib
 Libs: -L${libdir} -lpng@PNGLIB_MAJOR@@PNGLIB_MINOR@
 Libs.private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
zlib should be injected only when pkgconfig is ran requesting flags suitable for static linking..