### PR TITLE
[CMake] Corrected typo regarding disabling PNG_INTEL_SSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
   if(index EQUAL -1)
     message(FATAL_ERROR
       " PNG_INTEL_SSE must be one of [${PNG_INTEL_SSE_POSSIBLE_VALUES}]")
-  elseif(NOT ${PNG_INTEL_SSE} STREQUAL "no")
+  elseif(NOT ${PNG_INTEL_SSE} STREQUAL "off")
     set(libpng_intel_sources
       intel/intel_init.c
       intel/filter_sse2_intrinsics.c)


### PR DESCRIPTION
The ideal solution would be to change PNG_INTEL_SSE into a proper cmake OPTION, but I'm not 100% confident casing on ON/OFF wouldn't be an issue so this is the smaller change. 
Regardless, code as is is broken as it's impossible to disable it should the user want to, for whatever reason