### PR TITLE
Let original HP/MS sRGB ICC profiles pass checks

### DIFF
--- a/png.c
+++ b/png.c
@@ -2167,15 +2167,15 @@ static const struct
     * match the D50 PCS illuminant in the header (it is in fact the D65 values,
     * so the white point is recorded as the un-adapted value.)  The profiles
     * below only differ in one byte - the intent - and are basically the same as
-    * the previous profile except for the mediaWhitePointTag error and a missing
+    * the previous profile except for the mediaWhitePointTag difference and no
     * chromaticAdaptationTag.
     */
    PNG_ICC_CHECKSUM(0xf784f3fb, 0x182ea552,
-       PNG_MD5(0x00000000, 0x00000000, 0x00000000, 0x00000000), 0, 1/*broken*/,
+       PNG_MD5(0x00000000, 0x00000000, 0x00000000, 0x00000000), 0, 0,
        "1998/02/09 06:49:00", 3144, "HP-Microsoft sRGB v2 perceptual")
 
    PNG_ICC_CHECKSUM(0x0398f3fc, 0xf29e526d,
-       PNG_MD5(0x00000000, 0x00000000, 0x00000000, 0x00000000), 1, 1/*broken*/,
+       PNG_MD5(0x00000000, 0x00000000, 0x00000000, 0x00000000), 1, 0,
        "1998/02/09 06:49:00", 3144, "HP-Microsoft sRGB v2 media-relative")
 };
 


### PR DESCRIPTION
Following the rationale for letting these profiles pass the checks.

Most importantly, the technical rationale: The HP/MS sRGB profile is *not* broken, and therefore no reason exists for it to arbitrarily fail the checks. It's whitepoint is set to the D65 values, but this is not an error for ICC v2 profiles like this one - the ICC itself recommends using a media white of D50 (and storing chromatic adaptation information in the 'chad' tag), but it is *not a requirement* in that case. See http://www.color.org/srgbprofiles.xalter#v2

There's also practical rationale:
- The presence of these checks tends to burden end-users (and in some cases developers/packagers) with undue confusion, because graphical applications or intermediate libraries used by such applications which in turn use libpng may make any error/warning messages coming from libpng visible in the form of a popup modal window, for perfectly valid PNG images (and likewise, perfectly valid embedded sRGB profiles), whilst not pointing to any real problem ("Warning: The sky is blue!" - well, yes, but so what?).
- The HP/MS sRGB profile is still the _original_ sRGB profile, with millions upon millions of copies circulating in active use, it ships with Windows from versions 98 through 10 (and likely future versions as well), and many applications including Photoshop ship an identical sRGB profile, or use the system sRGB profile. Graphical assets used in a very wide variety of software are created (and will keep getting created) with this profile embedded.
- The HP/MS sRGB profile is not the only valid sRGB ICCv2 profile that has a D65 whitepoint (ArgyllCMS ships its own equivalent sRGB profile).
- It is unrealistic to expect millions of existing PNGs to be re-saved just to pass an (imho) ill-conceived check. The answer so far by most distributions and upstreams seems to have been to just disable the checks entirely, thus demoting them to superfluous code.