### PR TITLE
Some more trivial source typos

### DIFF
--- a/contrib/conftest/pngcp.dfa
+++ b/contrib/conftest/pngcp.dfa
@@ -52,6 +52,6 @@ option TEXT on
 option USER_LIMITS on
 option SET_USER_LIMITS on
 
-# these are are just required for specific customizations
+# these are just required for specific customizations
 option WRITE_CUSTOMIZE_ZTXT_COMPRESSION on
 option WRITE_CUSTOMIZE_COMPRESSION on

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -2726,7 +2726,7 @@ compare_two_images(Image *a, Image *b, int via_linear,
                result = 0;
          }
 
-         /* If reqested copy the error values back from the Transform. */
+         /* If requested, copy the error values back from the Transform. */
          if (a->opts & ACCUMULATE)
          {
             tr.error_ptr[0] = tr.error[0];
@@ -2932,7 +2932,7 @@ compare_two_images(Image *a, Image *b, int via_linear,
       }
    }
 
-   /* If reqested copy the error values back from the Transform. */
+   /* If requested, copy the error values back from the Transform. */
    if (a->opts & ACCUMULATE)
    {
       tr.error_ptr[0] = tr.error[0];

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -961,7 +961,7 @@ bits_of(png_uint_32 num)
    return b; /* 0..32 */
 }
 
-/* Main interface to file storeage, after writing a new PNG file (see the API
+/* Main interface to file storage, after writing a new PNG file (see the API
  * below) call store_storefile to store the result with the given name and id.
  */
 static void
@@ -4706,7 +4706,7 @@ make_error(png_store* const ps, png_byte const colour_type,
       else
       {
          /* Now write the whole image, just to make sure that the detected, or
-          * undetected, errro has not created problems inside libpng.  This
+          * undetected, error has not created problems inside libpng.  This
           * doesn't work if there was a png_error in png_write_info because that
           * can abort before PLTE was written.
           */
@@ -9299,7 +9299,7 @@ gamma_info_imp(gamma_display *dp, png_structp pp, png_infop pi)
          int mode = dp->do_background - ALPHA_MODE_OFFSET;
 
          /* The gamma value is the output gamma, and is in the standard,
-          * non-inverted, represenation.  It provides a default for the PNG file
+          * non-inverted, representation.  It provides a default for the PNG file
           * gamma, but since the file has a gAMA chunk this does not matter.
           */
          const double sg = dp->screen_gamma;

--- a/contrib/tools/pngcp.c
+++ b/contrib/tools/pngcp.c
@@ -2220,7 +2220,7 @@ cp_one_file(struct display *dp, const char *filename, const char *destname)
    strcpy(dp->best, dp->curr);
    dp->best_size = dp->write_size;
 
-   if (dp->nsp > 0) /* interating over lists */
+   if (dp->nsp > 0) /* iterating over lists */
    {
       char *tmpname, tmpbuf[(sizeof dp->namebuf) + 4];
       assert(dp->curr[0] == ' ' && dp->tsp > 0);

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -772,7 +772,7 @@ skip_chunk_type(const struct global *global, png_uint_32 type)
          return 0;
 
       /* Chunks that specify gamma encoding which should therefore only be
-       * removed the the user insists:
+       * removed if the user insists:
        */
       case png_gAMA: case png_sRGB:
          if (global->skip >= SKIP_ALL)
@@ -3152,7 +3152,7 @@ read_chunk(struct file *file)
       }
    }
 
-   /* Control gets to here if the the stream seems invalid or damaged in some
+   /* Control gets to here if the stream seems invalid or damaged in some
     * way.  Either there was a problem reading all the expected data (this
     * chunk's data, its CRC and the length and type of the next chunk) or the
     * next chunk length/type are invalid.  Notice that the cases that end up
@@ -3710,7 +3710,7 @@ usage(const char *prog)
 "            practice most programs will ignore it.",
 "        bKGD [transform]: This is used by libpng transforms."
 "    --max=<number>:",
-"      Use IDAT chunks sized <number>.  If no number is given the the IDAT",
+"      Use IDAT chunks sized <number>.  If no number is given the IDAT",
 "      chunks will be the maximum size permitted; 2^31-1 bytes.  If the option",
 "      is omitted the original chunk sizes will not be changed.  When the",
 "      option is given --strip=unsafe is set automatically. This may be",

--- a/libpng-manual.txt
+++ b/libpng-manual.txt
@@ -4055,7 +4055,7 @@ Flags containing additional information about the image are held in
 the 'flags' field of png_image.
 
   PNG_IMAGE_FLAG_COLORSPACE_NOT_sRGB == 0x01
-    This indicates the the RGB values of the in-memory bitmap do not
+    This indicates that the RGB values of the in-memory bitmap do not
     correspond to the red, green and blue end-points defined by sRGB.
 
   PNG_IMAGE_FLAG_FAST == 0x02

--- a/libpng.3
+++ b/libpng.3
@@ -4573,7 +4573,7 @@ Flags containing additional information about the image are held in
 the 'flags' field of png_image.
 
   PNG_IMAGE_FLAG_COLORSPACE_NOT_sRGB == 0x01
-    This indicates the the RGB values of the in-memory bitmap do not
+    This indicates that the RGB values of the in-memory bitmap do not
     correspond to the red, green and blue end-points defined by sRGB.
 
   PNG_IMAGE_FLAG_FAST == 0x02

--- a/png.c
+++ b/png.c
@@ -1121,7 +1121,7 @@ png_colorspace_set_gamma(png_const_structrp png_ptr,
     png_colorspacerp colorspace, png_fixed_point gAMA)
 {
    /* Changed in libpng-1.5.4 to limit the values to ensure overflow can't
-    * occur.  Since the fixed point representation is asymetrical it is
+    * occur.  Since the fixed point representation is asymmetrical it is
     * possible for 1/gamma to overflow the limit of 21474 and this means the
     * gamma value must be at least 5/100000 and hence at most 20000.0.  For
     * safety the limits here are a little narrower.  The values are 0.00016 to

--- a/png.h
+++ b/png.h
@@ -2967,7 +2967,7 @@ typedef struct
  * 'flags' field of png_image.
  */
 #define PNG_IMAGE_FLAG_COLORSPACE_NOT_sRGB 0x01
-   /* This indicates the the RGB values of the in-memory bitmap do not
+   /* This indicates that the RGB values of the in-memory bitmap do not
     * correspond to the red, green and blue end-points defined by sRGB.
     */
 


### PR DESCRIPTION
Found via `codespell` and `grep`