### PR TITLE
ARM: Disable hand-written AArch32 NEON on AArch64

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -174,7 +174,10 @@
 #     else /* !defined __ARM_NEON__ */
          /* The 'intrinsics' code simply won't compile without this -mfpu=neon:
           */
-#        define PNG_ARM_NEON_IMPLEMENTATION 2
+#        if !defined(__aarch64__)
+            /* The assembler code currently does not work on ARM64 */
+#          define PNG_ARM_NEON_IMPLEMENTATION 2
+#        endif /* __aarch64__ */
 #     endif /* __ARM_NEON__ */
 #  endif /* !PNG_ARM_NEON_IMPLEMENTATION */
 


### PR DESCRIPTION
The NEON assembler does not work on AArch64 and might not properly enable the intrinsics version in all cases. This should enable the intrinsics version.

Note that it doesn't disable the AArch32 code on GCC < 4.6 but GCC did not gain AArch64 support until 4.8 so this isn't an issue.