### PR TITLE
Allow overwriting library debug postfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ endif(PNG_HARDWARE_OPTIMIZATIONS)
 set(PNG_LIB_NAME png${PNGLIB_MAJOR}${PNGLIB_MINOR})
 
 # to distinguish between debug and release lib
-set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_DEBUG_POSTFIX CACHE "d")
 
 include(CheckCSourceCompiles)
 option(ld-version-script "Enable linker version script" ON)


### PR DESCRIPTION
This allows overwriting the library debug postfix from the outside by making it a cmake cache variable.