### PR TITLE
Fix a memory leak in the ARM-specific riffled palette optimization

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -959,6 +959,12 @@ png_read_destroy(png_structrp png_ptr)
    png_ptr->quantize_index = NULL;
 #endif
 
+#if defined(PNG_READ_EXPANDED_SUPPORTED) && \
+    defined(PNG_ARM_NEON_IMPLEMENTATION)
+   png_free(png_ptr, png_ptr->riffled_palette);
+   png_ptr->riffled_palette = NULL;
+#endif
+
    if ((png_ptr->free_me & PNG_FREE_PLTE) != 0)
    {
       png_zfree(png_ptr, png_ptr->palette);

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -228,10 +228,6 @@ struct png_struct_def
                                * big_row_buf; while writing it is separately
                                * allocated.
                                */
-#ifdef PNG_READ_EXPAND_SUPPORTED
-   /* Buffer to accelerate palette transformations. */
-   png_bytep riffled_palette;
-#endif
 #ifdef PNG_WRITE_FILTER_SUPPORTED
    png_bytep try_row;    /* buffer to save trial row when filtering */
    png_bytep tst_row;    /* buffer to save best trial row when filtering */
@@ -353,6 +349,14 @@ struct png_struct_def
 #ifdef PNG_READ_QUANTIZE_SUPPORTED
    png_bytep palette_lookup; /* lookup table for quantizing */
    png_bytep quantize_index; /* index translation for palette files */
+#endif
+
+#if defined(PNG_READ_EXPAND_SUPPORTED) && \
+    defined(PNG_ARM_NEON_IMPLEMENTATION)
+   /* Buffer to accelerate palette transformations.
+    * (Currently used on ARM Neon only.)
+    */
+   png_bytep riffled_palette;
 #endif
 
 /* Options */

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -948,10 +948,6 @@ png_write_destroy(png_structrp png_ptr)
    png_free_buffer_list(png_ptr, &png_ptr->zbuffer_list);
    png_free(png_ptr, png_ptr->row_buf);
    png_ptr->row_buf = NULL;
-#ifdef PNG_READ_EXPANDED_SUPPORTED
-   png_free(png_ptr, png_ptr->riffled_palette);
-   png_ptr->riffled_palette = NULL;
-#endif
 #ifdef PNG_WRITE_FILTER_SUPPORTED
    png_free(png_ptr, png_ptr->prev_row);
    png_free(png_ptr, png_ptr->try_row);


### PR DESCRIPTION
The riffled palette was incorrectly deallocated in png_write_destroy,
instead of png_read_destroy.