### PR TITLE
Clean up riffled palette in more places, fix tests

### DIFF
--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -10472,6 +10472,9 @@ gamma_test(png_modifier *pmIn, png_byte colour_typeIn,
             d.this.ps->validated = 1;
       }
 
+      /* Clean up png_structp, without destroying the structure itself. */
+      png_destroy_read_struct(&(d.pm->this.pread), &pi, &pi);
+
       modifier_reset(d.pm);
 
       if (d.pm->log && !d.threshold_test && !d.this.speed)

--- a/pngread.c
+++ b/pngread.c
@@ -959,6 +959,11 @@ png_read_destroy(png_structrp png_ptr)
    png_ptr->quantize_index = NULL;
 #endif
 
+#if defined(PNG_READ_EXPAND_SUPPORTED)
+   png_free(png_ptr, png_ptr->riffled_palette);
+   png_ptr->riffled_palette = NULL;
+#endif
+
    if ((png_ptr->free_me & PNG_FREE_PLTE) != 0)
    {
       png_zfree(png_ptr, png_ptr->palette);


### PR DESCRIPTION
This PR adds additional cleanup logic in `png_read_destroy` to deallocate the palette if necessary and also fixes the `pngvalid.c` regression tests to call this method. This should fix #266.