### PR TITLE
Fix typo in the new v2 license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,7 +13,7 @@ PNG Reference Library License version 2
 The software is supplied "as is", without warranty of any kind,
 express or implied, including, without limitation, the warranties
 of merchantability, fitness for a particular purpose, title, and
-non-infringement.  In no even shall the Copyright owners, or
+non-infringement.  In no event shall the Copyright owners, or
 anyone distributing the software, be liable for any damages or
 other liability, whether in contract, tort or otherwise, arising
 from, out of, or in connection with the software, or the use or


### PR DESCRIPTION
The new v2 license has a typo in one of the sentences. I guess it was introduced when the text was manually re-formatted from the all caps style of other licenses which contain a very similar sentence (e.g. BSD).