### PR TITLE
Use arm_neon.h when compiling aarch64 intrinsics with clang-cl.

### DIFF
--- a/arm/filter_neon_intrinsics.c
+++ b/arm/filter_neon_intrinsics.c
@@ -18,7 +18,7 @@
 /* This code requires -mfpu=neon on the command line: */
 #if PNG_ARM_NEON_IMPLEMENTATION == 1 /* intrinsics code from pngpriv.h */
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && defined(_M_ARM64) && !defined(__clang__)
 #  include <arm64_neon.h>
 #else
 #  include <arm_neon.h>

--- a/arm/palette_neon_intrinsics.c
+++ b/arm/palette_neon_intrinsics.c
@@ -14,7 +14,7 @@
 
 #if PNG_ARM_NEON_IMPLEMENTATION == 1
 
-#if defined(_MSC_VER) && defined(_M_ARM64)
+#if defined(_MSC_VER) && defined(_M_ARM64) && !defined(__clang__)
 #  include <arm64_neon.h>
 #else
 #  include <arm_neon.h>

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -21,7 +21,7 @@
 #ifdef PNG_ARM_NEON_IMPLEMENTATION
 #  if PNG_ARM_NEON_IMPLEMENTATION == 1
 #    define PNG_ARM_NEON_INTRINSICS_AVAILABLE
-#    if defined(_MSC_VER) && defined(_M_ARM64)
+#    if defined(_MSC_VER) && defined(_M_ARM64) && !defined(__clang__)
 #      include <arm64_neon.h>
 #    else
 #      include <arm_neon.h>


### PR DESCRIPTION
When building for Windows aarch64 with clang-cl, linking fails due to a number of missing ARM intrinsics symbols. This is because arm64_neon.h is an MSVC-specific header and clang-cl doesn't know what to do with it.

The solution is to add a check for clang in the conditional so that clang-cl builds will use arm_neon.h like clang builds on other platforms.