### PR TITLE
Fix Memory leak in case eXIf has incorrect crc

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -2087,10 +2087,10 @@ png_handle_eXIf(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       }
    }
 
-   if (png_crc_finish(png_ptr, 0) != 0)
-      return;
-
-   png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+   if (png_crc_finish(png_ptr, 0) == 0)
+   {
+      png_set_eXIf_1(png_ptr, info_ptr, length, info_ptr->eXIf_buf);
+   }
 
    png_free(png_ptr, info_ptr->eXIf_buf);
    info_ptr->eXIf_buf = NULL;


### PR DESCRIPTION
problem description: 
Imagine a bitstream with an eXIf data segment that has invalid CRC.
if png_crc_finish() fails at line 2090, info_ptr->eXIf_buf is not free'd (despite the free_me setting at line 2062) because png_free_data() is not called. 
png_read_info() is actually looping several time over the png_eXIf chunk, calling png_handle_eXIf() several time in a row without freeing the buffer.

This patch fixes the problem by leaving info_ptr's content in a clean state in case of failure, like is done at 2084.

I can probably supply privately a repro vector for this failure case.

skal/