### PR TITLE
Close _BSD_SOURCE warning

### DIFF
--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -22,6 +22,8 @@
 #define _ISOC99_SOURCE 1 /* For floating point */
 #define _GNU_SOURCE 1 /* For the floating point exception extension */
 #define _BSD_SOURCE 1 /* For the floating point exception extension */
+#define _DEFAULT_SOURCE 1 /* For the floating point exception extension */
+
 
 #include <signal.h>
 #include <stdio.h>


### PR DESCRIPTION
I got a warning while compiling under Ubuntu 18.04 and gcc 7.4.
```
/usr/include/features.h:184:3: warning: #warning "__BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
 # warning "__BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
    ^~~~~~~
```
the safest (glibc backwards compatibility) way should be define "#define _DEFAULT_SOURCE 1".

The official manpage quote:
```
To allow code that requires
_BSD_SOURCE in glibc 2.19 and earlier and _DEFAULT_SOURCE in
glibc 2.20 and later to compile without warnings, define both
_BSD_SOURCE and _DEFAULT_SOURCE.
```