### PR TITLE
Add an __LLVM,__asm section for clang builds on ARM

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Authors, for copyright and licensing purposes.
  * Google Inc.
    - Matt Sarett
    - Mike Klein
+   - Dan Field
 
 The build projects, the build scripts, the test scripts, and other
 files in the "projects", "scripts" and "tests" directories, have other

--- a/arm/filter_neon.S
+++ b/arm/filter_neon.S
@@ -20,6 +20,10 @@
 .section .note.GNU-stack,"",%progbits /* mark stack as non-executable */
 #endif
 
+#ifdef __clang__
+.section __LLVM,__asm
+#endif
+
 #ifdef PNG_READ_SUPPORTED
 
 /* Assembler NEON support - only works for 32-bit ARM (i.e. it does not work for


### PR DESCRIPTION
When building with upstream clang and using the `-fembed-bitcode` or `-fembed-bitcode-marker`, it expects to find this section.  Without this section, the build will fail complaining that the object file doesn't have bitcode.

For unknown reasons, the Xcode version of clang does _not_ need this to compile with bitcode, but it doesn't hurt anything to have it in that case.