### PR TITLE
Fix CMake build with Emscripten

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(NOT PNG_BUILD_ZLIB)
   include_directories(${ZLIB_INCLUDE_DIR})
 endif()
 
-if(UNIX AND NOT APPLE AND NOT BEOS AND NOT HAIKU)
+if(UNIX AND NOT APPLE AND NOT BEOS AND NOT HAIKU AND NOT EMSCRIPTEN)
   find_library(M_LIBRARY m)
 else()
   # libm is not needed and/or not available


### PR DESCRIPTION
When building with Emscripten, linkage to libm is neither required nor
does it will. As find_library will fail, M_LIBRARY will be set to
NOTFOUND and the build would fail later. The build works just fine
without libm linkage.