### PR TITLE
Avoid -Wundef warnings for non-x86 architectures too

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -185,6 +185,8 @@
       /* Use the intrinsics code by default. */
 #     define PNG_ARM_NEON_IMPLEMENTATION 1
 #  endif
+#else /* PNG_ARM_NEON_OPT == 0 */
+#     define PNG_ARM_NEON_IMPLEMENTATION 0
 #endif /* PNG_ARM_NEON_OPT > 0 */
 
 #ifndef PNG_MIPS_MSA_OPT

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -265,11 +265,15 @@
 #  ifndef PNG_MIPS_MSA_IMPLEMENTATION
 #     define PNG_MIPS_MSA_IMPLEMENTATION 1
 #  endif
+#else
+#  define PNG_MIPS_MSA_IMPLEMENTATION 0
 #endif /* PNG_MIPS_MSA_OPT > 0 */
 
 #if PNG_POWERPC_VSX_OPT > 0
 #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_vsx
 #  define PNG_POWERPC_VSX_IMPLEMENTATION 1
+#else
+#  define PNG_POWERPC_VSX_IMPLEMENTATION 0
 #endif
 
 


### PR DESCRIPTION
Define this symbol as 0 instead of leaving it undefined when not using
ARM NEON optimizations.

No real changes, but just avoid a bunch of

"PNG_ARM_NEON_IMPLEMENTATION" is not defined, evaluates to 0 [-Wundef]

warnings when building the library.