### PR TITLE
cmake: Fix cross-compilation on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,22 @@ option(PNG_HARDWARE_OPTIMIZATIONS "Enable hardware optimizations" ON)
 set(PNG_PREFIX "" CACHE STRING "Prefix to add to the API function names")
 set(DFA_XTRA "" CACHE FILEPATH "File containing extra configuration settings")
 
+# CMake currently sets CMAKE_SYSTEM_PROCESSOR to one of x86_64 or arm64 on macOS,
+# based upon the OS architecture, not the target architecture. As such, we need
+# to check CMAKE_OSX_ARCHITECTURES to identify which hardware-specific flags to
+# enable. Note that this will fail if you attempt to build a universal binary in
+# a single cmake invocation.
+if (APPLE AND CMAKE_OSX_ARCHITECTURES)
+  set(TARGET_ARCH ${CMAKE_OSX_ARCHITECTURES})
+else()
+  set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+endif()
+
 if(PNG_HARDWARE_OPTIMIZATIONS)
 
 # Set definitions and sources for ARM.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
-  CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+if(TARGET_ARCH MATCHES "^arm" OR
+  TARGET_ARCH MATCHES "^aarch64")
   set(PNG_ARM_NEON_POSSIBLE_VALUES check on off)
   set(PNG_ARM_NEON "check"
       CACHE STRING "Enable ARM NEON optimizations: check|on|off; check is default")
@@ -95,8 +106,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
 endif()
 
 # Set definitions and sources for PowerPC.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc*" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64*")
+if(TARGET_ARCH MATCHES "^powerpc*" OR
+   TARGET_ARCH MATCHES "^ppc64*")
   set(PNG_POWERPC_VSX_POSSIBLE_VALUES on off)
   set(PNG_POWERPC_VSX "on"
       CACHE STRING "Enable POWERPC VSX optimizations: on|off; on is default")
@@ -118,8 +129,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc*" OR
 endif()
 
 # Set definitions and sources for Intel.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^x86_64*")
+if(TARGET_ARCH MATCHES "^i?86" OR
+   TARGET_ARCH MATCHES "^x86_64*")
   set(PNG_INTEL_SSE_POSSIBLE_VALUES on off)
   set(PNG_INTEL_SSE "on"
       CACHE STRING "Enable INTEL_SSE optimizations: on|off; on is default")
@@ -141,8 +152,8 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
 endif()
 
 # Set definitions and sources for MIPS.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "mips64el*")
+if(TARGET_ARCH MATCHES "mipsel*" OR
+   TARGET_ARCH MATCHES "mips64el*")
   set(PNG_MIPS_MSA_POSSIBLE_VALUES on off)
   set(PNG_MIPS_MSA "on"
       CACHE STRING "Enable MIPS_MSA optimizations: on|off; on is default")
@@ -166,26 +177,26 @@ endif()
 else(PNG_HARDWARE_OPTIMIZATIONS)
 
 # Set definitions and sources for ARM.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+if(TARGET_ARCH MATCHES "^arm" OR
+   TARGET_ARCH MATCHES "^aarch64")
   add_definitions(-DPNG_ARM_NEON_OPT=0)
 endif()
 
 # Set definitions and sources for PowerPC.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc*" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc64*")
+if(TARGET_ARCH MATCHES "^powerpc*" OR
+   TARGET_ARCH MATCHES "^ppc64*")
   add_definitions(-DPNG_POWERPC_VSX_OPT=0)
 endif()
 
 # Set definitions and sources for Intel.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^i?86" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "^x86_64*")
+if(TARGET_ARCH MATCHES "^i?86" OR
+   TARGET_ARCH MATCHES "^x86_64*")
   add_definitions(-DPNG_INTEL_SSE_OPT=0)
 endif()
 
 # Set definitions and sources for MIPS.
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "mipsel*" OR
-   CMAKE_SYSTEM_PROCESSOR MATCHES "mips64el*")
+if(TARGET_ARCH MATCHES "mipsel*" OR
+   TARGET_ARCH MATCHES "mips64el*")
   add_definitions(-DPNG_MIPS_MSA_OPT=0)
 endif()
 


### PR DESCRIPTION
When cross-compiling on macOS (e.g., on Intel for arm64 or vice versa) using the CMAKE_OSX_ARCHITECTURES variable, the CMAKE_SYSTEM_PROCESSOR variable does not get updated with the target architecture; instead it uses the host CPU architecture (or, in some versions of cmake, the architecture of the `cmake` binary itself, which may be different).

This appears to be a cmake bug/design decision, and may be a consequence of the fact that you can specify multiple architectures in the CMAKE_OSX_ARCHITECTURES variable to generate universal/fat binaries. However, it does cause problems when trying to cross-compile libpng with hardware optimisations enabled, as the incorrect architecture-specific files or flags get included/enabled.

This pull request fixes cross-compilation (and native compilation, when using an older version of cmake on Apple Silicon) on macOS, and should have no effect on other platforms. Note that this will likely fail if the user tries to build a universal binary (e.g., `CMAKE_OSX_ARCHITECTURES=arm64;x86_64`), but that would have been the case before this patch too. The only way to build libpng as a universal binary with hardware optimisations would be to perform two separate builds then `lipo` them together.