### PR TITLE
Make CMake compatible with Xcode's 'New build system'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,18 +412,10 @@ else()
                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/checksym.awk"
                        "${CMAKE_CURRENT_SOURCE_DIR}/scripts/symbols.def")
 
-  add_custom_target(symbol-check
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk")
-
   generate_copy("${CMAKE_CURRENT_BINARY_DIR}/scripts/sym.out"
                 "${CMAKE_CURRENT_BINARY_DIR}/libpng.sym")
   generate_copy("${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out"
                 "${CMAKE_CURRENT_BINARY_DIR}/libpng.vers")
-
-  add_custom_target(genvers
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/libpng.vers")
-  add_custom_target(gensym
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/libpng.sym")
 
   add_custom_target("genprebuilt"
                     COMMAND "${CMAKE_COMMAND}"


### PR DESCRIPTION
As of CMake 3.19, [CMake now defaults to Xcode's new build system when generating for Xcode 12.0 or higher](https://cmake.org/cmake/help/v3.19/release/3.19.html#generators).

If I run `cmake -G Xcode -B build` to generate a macOS build with Xcode, I get these configuration errors (they show one at a time, you have to fix one to see the next one):

```
CMake Error in CMakeLists.txt:
  The custom command generating

    /Users/steve/Code/github/libpng/build/pnglibconf.c

  is attached to multiple targets:

    genfiles
    gensym
    genvers

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```
```
  CMake Error in CMakeLists.txt:
  The custom command generating

    /Users/steve/Code/github/libpng/build/scripts/symbols.out

  is attached to multiple targets:

    symbol-check
    genfiles

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```
```
  CMake Error in CMakeLists.txt:
  The custom command generating

    /Users/steve/Code/github/libpng/build/pnglibconf.c

  is attached to multiple targets:

    genfiles
    genvers

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".
```

I noticed that the `symbol-check`, `genvers`, and `gensym` targets weren't referenced anywhere else in the source tree so I removed them, which fixed the error. The `genfiles` target also references these files and is a dependent of `png` and `png_static` so that's the target that's actually getting used in the build.

I confirmed that this fixed the build with CMake 3.19. I also ran builds with CMake 3.18 to make sure generating to Xcode's legacy build system still works. Also made sure everything still built on Windows, Linux, iOS, and Android through my CI checks:
https://github.com/ssrobins/conan-libpng/pull/3