### PR TITLE
Guard __LLVM,__asm with __APPLE__

### DIFF
--- a/arm/filter_neon.S
+++ b/arm/filter_neon.S
@@ -20,7 +20,7 @@
 .section .note.GNU-stack,"",%progbits /* mark stack as non-executable */
 #endif
 
-#ifdef __clang__
+#if defined(__clang__) && defined(__APPLE__)
 .section __LLVM,__asm
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/glennrp/libpng/issues/347

This non-standard section is only meant to be used on Apple platforms and may not be supported on others.