### PR TITLE
Use __UINTPTR_TYPE__ for png_ptruint when available

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -492,7 +492,9 @@
    static_cast<type>(static_cast<const void*>(value))
 #else
 #  define png_voidcast(type, value) (value)
-#  ifdef _WIN64
+#  ifdef __UINTPTR_TYPE__
+      typedef __UINTPTR_TYPE__ png_ptruint;
+#  elif defined(_WIN64)
 #     ifdef __GNUC__
          typedef unsigned long long png_ptruint;
 #     else


### PR DESCRIPTION
This ensures that libpng can also be used on archictures where uintptr_t
is not the same as unsigned long. This is needed e.g. for CHERI-extended
architectures such CHERI-RISC-V or Arm Morello where uintptr_t is twice
the size of long since it carries additional metadata. Without this
change the CHERI build fails and if we disable -Werror, the binary will
crash at run time.
```
/Users/alex/cheri/libpng/pngerror.c:83:30: error: cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced [-Werror,-Wcheri-capability-misuse]
      (*(png_ptr->error_fn))(png_constcast(png_structrp,png_ptr),
                             ^
/Users/alex/cheri/libpng/pngpriv.h:504:39: note: expanded from macro 'png_constcast'
#  define png_constcast(type, value) ((type)(png_ptruint)(const void*)(value))
```
The ISO C standard compliant fix for this would be to use uintptr_t from
<stdint.h>, but I am not sure if this is supported by the minimum compiler
version. Therefore, use the compiler-defined __UINTPTR_TYPE__ macro
(supported in GCC 4.6+ and Clang since about 3.0) before checking for
_WIN64 and falling back to unsigned long.