### PR TITLE
Fix shared build on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,7 +536,7 @@ if(PNG_SHARED)
   endif()
   target_link_libraries(png ${ZLIB_LIBRARIES} ${M_LIBRARY})
 
-  if(UNIX AND AWK)
+  if(UNIX AND AWK AND NOT ANDROID)
     if(HAVE_LD_VERSION_SCRIPT)
       set_target_properties(png PROPERTIES
                             LINK_FLAGS "-Wl,--version-script='${CMAKE_CURRENT_BINARY_DIR}/libpng.vers'")


### PR DESCRIPTION
The ld version script is not generated on Android, so also don't try to use it there.