### PR TITLE
FIx various typos

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2295,7 +2295,7 @@ Version 1.4.0beta58 [May 14, 2009]
   Clarified usage of sig_bit versus sig_bit_p in example.c (Vincent Torri)
 
 Version 1.4.0beta59 [May 15, 2009]
-  Reformated sources in libpng style (3-space intentation, comment format)
+  Reformated sources in libpng style (3-space indentation, comment format)
   Fixed typo in libpng docs (PNG_FILTER_AVE should be PNG_FILTER_AVG)
   Added sections about the git repository and our coding style to the
     documentation
@@ -3886,7 +3886,7 @@ Version 1.6.0beta06 [January 24, 2012]
 Version 1.6.0beta07 [January 28, 2012]
   Eliminated Intel icc/icl compiler warnings. The Intel (GCC derived)
     compiler issues slightly different warnings from those issued by the
-    current vesions of GCC. This eliminates those warnings by
+    current versions of GCC. This eliminates those warnings by
     adding/removing casts and small code rewrites.
   Updated configure.ac from autoupdate: added --enable-werror option.
     Also some layout regularization and removal of introduced tab characters

--- a/contrib/libtests/makepng.c
+++ b/contrib/libtests/makepng.c
@@ -1876,7 +1876,7 @@ main(int argc, char **argv)
          }
    }
 
-   /* small and colors are incomparible (will probably crash if both are used at
+   /* small and colors are incompatible (will probably crash if both are used at
     * the same time!)
     */
    if (small && colors[0] != 0)

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -7643,7 +7643,7 @@ image_transform_png_set_rgb_to_gray_ini(const image_transform *this,
 
    else
    {
-      /* The default (built in) coeffcients, as above: */
+      /* The default (built in) coefficients, as above: */
 #     if PNG_LIBPNG_VER < 10700
          data.red_coefficient = 6968 / 32768.;
          data.green_coefficient = 23434 / 32768.;
@@ -11768,7 +11768,7 @@ int main(int argc, char **argv)
 
    /* The following allows results to pass if they correspond to anything in the
     * transformed range [input-.5,input+.5]; this is is required because of the
-    * way libpng treates the 16_TO_8 flag when building the gamma tables in
+    * way libpng treats the 16_TO_8 flag when building the gamma tables in
     * releases up to 1.6.0.
     *
     * TODO: review this

--- a/contrib/libtests/timepng.c
+++ b/contrib/libtests/timepng.c
@@ -527,7 +527,7 @@ int main(int argc, char **argv)
       }
    }
 
-   else if (nfiles == 0) /* Read from stdin withoout --dissemble */
+   else if (nfiles == 0) /* Read from stdin without --dissemble */
    {
       char filename[FILENAME_MAX+1];
 

--- a/contrib/tools/genpng.c
+++ b/contrib/tools/genpng.c
@@ -453,7 +453,7 @@ check_square(const struct arg *arg, double x, double y)
  * { inside_circle_filled, check_circle_filled },
  * { inside_circle, check_circle }
  *
- * The functions here are analoguous to the square ones; however, they check
+ * The functions here are analogous to the square ones; however, they check
  * the corresponding ellipse as opposed to the rectangle.
  */
 static int

--- a/contrib/tools/pngcp.c
+++ b/contrib/tools/pngcp.c
@@ -336,7 +336,7 @@ static const option options[] =
 #  define VLC(name) VLCIDAT(name) VLCiCCP(name) VLCzTXt(name)
 
 #  ifdef PNG_SW_COMPRESS_png_level
-      /* The libpng compression level isn't searched because it justs sets the
+      /* The libpng compression level isn't searched because it just sets the
        * other things that are searched!
        */
       VLO("compression", compression, 0)

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -1598,7 +1598,7 @@ chunk_init(struct chunk * const chunk, struct file * const file)
    chunk->chunk_length = file->length;
    chunk->chunk_type = file->type;
 
-   /* Compresssed/uncompressed size information (from the zlib control structure
+   /* Compressed/uncompressed size information (from the zlib control structure
     * that is used to check the compressed data in a chunk.)
     */
    chunk->uncompressed_digits = 0;
@@ -2929,7 +2929,7 @@ process_chunk(struct file *file, png_uint_32 file_crc, png_uint_32 next_length,
    }
 
    /* Control reaches this point if the chunk must be skipped.  For chunks other
-    * than IDAT this means that the zlib compressed data is fatally damanged and
+    * than IDAT this means that the zlib compressed data is fatally damaged and
     * the chunk will not be passed to libpng.  For IDAT it means that the end of
     * the IDAT stream has not yet been reached and we must handle the next
     * (IDAT) chunk.  If the LZ data in an IDAT stream cannot be read 'stop' must

--- a/png.c
+++ b/png.c
@@ -720,7 +720,7 @@ png_init_io(png_structrp png_ptr, png_FILE_p fp)
  *
  * Where UNSIGNED_MAX is the appropriate maximum unsigned value, so when the
  * negative integral value is added the result will be an unsigned value
- * correspnding to the 2's complement representation.
+ * corresponding to the 2's complement representation.
  */
 void PNGAPI
 png_save_int_32(png_bytep buf, png_int_32 i)

--- a/png.h
+++ b/png.h
@@ -1446,7 +1446,7 @@ PNG_EXPORT(66, void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
  * mainly useful for testing, as the defaults should work with most users.
  * Those users who are tight on memory or want faster performance at the
  * expense of compression can modify them.  See the compression library
- * header file (zlib.h) for an explination of the compression functions.
+ * header file (zlib.h) for an explanation of the compression functions.
  */
 
 /* Set the filtering method(s) used by libpng.  Currently, the only valid
@@ -1501,7 +1501,7 @@ PNG_FIXED_EXPORT(209, void, png_set_filter_heuristics_fixed,
  * 0 - 9, corresponding directly to the zlib compression levels 0 - 9
  * (0 - no compression, 9 - "maximal" compression).  Note that tests have
  * shown that zlib compression levels 3-6 usually perform as well as level 9
- * for PNG images, and do considerably fewer caclulations.  In the future,
+ * for PNG images, and do considerably fewer calculations.  In the future,
  * these values may not correspond directly to the zlib compression levels.
  */
 #ifdef PNG_WRITE_CUSTOMIZE_COMPRESSION_SUPPORTED

--- a/scripts/dfn.awk
+++ b/scripts/dfn.awk
@@ -125,7 +125,7 @@ $1 ~ /^PNG_DFN_END_SORT/{
          # There is no matching "@.  Assume a split line
          else while (1) {
             if (getline nextline) {
-               # If the line starts with '#' it is a preprocesor line directive
+               # If the line starts with '#' it is a preprocessor line directive
                # from cc -E; skip it:
                if (nextline !~ /^#/) {
                   line = line " " nextline


### PR DESCRIPTION
Found via `codespell -q 3 -S ./ltmain.sh,./scripts/libtool.m4 -L ake,ans,ba,bloc,crashers,doed,inout,lengthh,maked,paeth,parm,parms,redy,unx`