### PR TITLE
fix windows issue when sources got with git but built with wsl fail.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,12 @@ if(NOT AWK OR ANDROID OR IOS)
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
   add_custom_target(genfiles) # Dummy
 else()
+
+  # copy awk scripts to ensure unix line endings
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/checksym.awk ${CMAKE_CURRENT_BINARY_DIR}/scripts/checksym.awk @ONLY NEWLINE_STYLE LF)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/options.awk  ${CMAKE_CURRENT_BINARY_DIR}/scripts/options.awk @ONLY NEWLINE_STYLE LF)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/dfn.awk      ${CMAKE_CURRENT_BINARY_DIR}/scripts/dfn.awk @ONLY NEWLINE_STYLE LF)
+
   # Generate .chk from .out with awk:
   # generate_chk(INPUT inputfile OUTPUT outputfile [DEPENDS dep1 [dep2...]])
   include(CMakeParseArguments)
@@ -352,13 +358,13 @@ else()
   # Generate scripts/pnglibconf.h
   generate_source(OUTPUT "scripts/pnglibconf.c"
                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.dfa"
-                          "${CMAKE_CURRENT_SOURCE_DIR}/scripts/options.awk"
+                          "${CMAKE_CURRENT_BINARY_DIR}/scripts/options.awk"
                           "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h")
 
   # Generate pnglibconf.c
   generate_source(OUTPUT "pnglibconf.c"
                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.dfa"
-                          "${CMAKE_CURRENT_SOURCE_DIR}/scripts/options.awk"
+                          "${CMAKE_CURRENT_BINARY_DIR}/scripts/options.awk"
                           "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h")
 
   if(PNG_PREFIX)
@@ -409,7 +415,7 @@ else()
 
   generate_chk(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out"
                OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk"
-               DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/checksym.awk"
+               DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/checksym.awk"
                        "${CMAKE_CURRENT_SOURCE_DIR}/scripts/symbols.def")
 
   add_custom_target(symbol-check

--- a/scripts/genchk.cmake.in
+++ b/scripts/genchk.cmake.in
@@ -10,6 +10,7 @@
 
 # Variables substituted from CMakeLists.txt
 set(SRCDIR "@CMAKE_CURRENT_SOURCE_DIR@")
+set(BINDIR "@CMAKE_CURRENT_BINARY_DIR@")
 
 set(AWK "@AWK@")
 
@@ -23,7 +24,7 @@ get_filename_component(OUTPUTDIR "${OUTPUT}" PATH)
 if("${INPUTEXT}" STREQUAL ".out" AND "${OUTPUTEXT}" STREQUAL ".chk")
   # Generate .chk from .out with awk (generic)
   file(REMOVE "${OUTPUT}" "${OUTPUTDIR}/${OUTPUTBASE}.new")
-  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/checksym.awk"
+  execute_process(COMMAND "${AWK}" -f "${BINDIR}/scripts/checksym.awk"
                           "${SRCDIR}/scripts/${INPUTBASE}.def"
                           "of=${OUTPUTDIR}/${OUTPUTBASE}.new"
                           "${INPUT}"


### PR DESCRIPTION
issue is that by default git for windows checks out text files with
CRLF line endings.  this is a problem for awk which is expecting
unix-style LF line endings.  so when an unsuspecting dev clones, but
then attempts to compile on WSL, Mingw, or Cygwin, they'll get an
error from awk.

fix used here is to leverage cmake's ability to configure a file and
perform eol conversions, so we copy the awk scripts from source to
binary. this portable method ensures they have LF endings and build
logic is updated to use the build dir version.

intentionally avoiding .gitattributes to avoid setting precedent.