### PR TITLE
Drop possible tail byte in hIST chunk

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -2139,7 +2139,7 @@ png_handle_hIST(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       readbuf[i] = png_get_uint_16(buf);
    }
 
-   if (png_crc_finish(png_ptr, 0) != 0)
+   if (png_crc_finish(png_ptr, (png_uint_32) (length - num * 2)) != 0)
       return;
 
    png_set_hIST(png_ptr, info_ptr, readbuf);


### PR DESCRIPTION
When I feed png decoder with complete chunks I expect that nothing remains in internal buffer.

Here is the case I've met (via fuzzing): empty palette followed by hIST chunk with 1 byte of payload.
Decoder gives a warning and picks one byte into internal buffer.
For the next chunk it uses this byte -- this is unexpected for the embedder (as chunk start for embedder and png decoder is placed at different positions).

There is no public API to check how much is stored in internal buffer, so it is better to be consistent on processing of "tails" of chunks.