### PR TITLE
arm: fix warning.

### DIFF
--- a/arm/palette_neon_intrinsics.c
+++ b/arm/palette_neon_intrinsics.c
@@ -84,10 +84,10 @@ png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
    {
       uint32x4_t cur;
       png_bytep sp = *ssp - i, dp = *ddp - (i << 2);
-      cur = vld1q_dup_u32 (riffled_palette + *(sp - 3));
-      cur = vld1q_lane_u32(riffled_palette + *(sp - 2), cur, 1);
-      cur = vld1q_lane_u32(riffled_palette + *(sp - 1), cur, 2);
-      cur = vld1q_lane_u32(riffled_palette + *(sp - 0), cur, 3);
+      cur = vld1q_dup_u32 ((void *)(riffled_palette + *(sp - 3)));
+      cur = vld1q_lane_u32((void *)(riffled_palette + *(sp - 2)), cur, 1);
+      cur = vld1q_lane_u32((void *)(riffled_palette + *(sp - 1)), cur, 2);
+      cur = vld1q_lane_u32((void *)(riffled_palette + *(sp - 0)), cur, 3);
       vst1q_u32((void *)dp, cur);
    }
    if (i != row_width)


### PR DESCRIPTION
[2022-11-03T13:35:51.087Z] libpng/arm/palette_neon_intrinsics.c: In function 'png_do_expand_palette_rgba8_neon':​ [2022-11-03T13:35:51.087Z] libpng/arm/palette_neon_intrinsics.c:86:44: warning: passing argument 1 of 'vld1q_dup_u32' from incompatible pointer type [-Wincompatible-pointer-types]​
[2022-11-03T13:35:51.087Z]    86 |       cur = vld1q_dup_u32 (riffled_palette + *(sp - 3));​
[2022-11-03T13:35:51.087Z]       |                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~​
[2022-11-03T13:35:51.087Z]       |                                            |​
[2022-11-03T13:35:51.087Z]       |                                            const png_uint_32 * {aka const unsigned int *}​
[2022-11-03T13:35:51.087Z] In file included from libpng/arm/palette_neon_intrinsics.c:20:​
[2022-11-03T13:35:51.087Z] prebuilts/gcc/linux/arm/lib/gcc/arm-none-eabi/10.3.1/include/arm_neon.h:10786:33: note: expected 'const uint32_t *' {aka 'const long unsigned int *'} but argument is of type 'const png_uint_32 *' {aka 'const unsigned int *'}​
[2022-11-03T13:35:51.087Z] 10786 | vld1q_dup_u32 (const uint32_t * __a)​
[2022-11-03T13:35:51.087Z]       |                ~~~~~~~~~~~~~~~~~^~~​
[2022-11-03T13:35:51.087Z] libpng/arm/palette_neon_intrinsics.c:87:44: warning: passing argument 1 of 'vld1q_lane_u32' from incompatible pointer type [-Wincompatible-pointer-types]​
[2022-11-03T13:35:51.087Z]    87 |       cur = vld1q_lane_u32(riffled_palette + *(sp - 2), cur, 1);​
[2022-11-03T13:35:51.087Z]       |                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~​
[2022-11-03T13:35:51.087Z]       |                                            |​
[2022-11-03T13:35:51.087Z]       |                                            const png_uint_32 * {aka const unsigned int *}​
[2022-11-03T13:35:51.087Z] In file included from libpng/arm/palette_neon_intrinsics.c:20:​
[2022-11-03T13:35:51.087Z] prebuilts/gcc/linux/arm/lib/gcc/arm-none-eabi/10.3.1/include/arm_neon.h:10592:34: note: expected 'const uint32_t *' {aka 'const long unsigned int *'} but argument is of type 'const png_uint_32 *' {aka 'const unsigned int *'}​
[2022-11-03T13:35:51.087Z] 10592 | vld1q_lane_u32 (const uint32_t * __a, uint32x4_t __b, const int __c)​
[2022-11-03T13:35:51.087Z]       |                 ~~~~~~~~~~~~~~~~~^~~​
[2022-11-03T13:35:51.087Z] libpng/arm/palette_neon_intrinsics.c:88:44: warning: passing argument 1 of 'vld1q_lane_u32' from incompatible pointer type [-Wincompatible-pointer-types]​
[2022-11-03T13:35:51.087Z]    88 |       cur = vld1q_lane_u32(riffled_palette + *(sp - 1), cur, 2);​
[2022-11-03T13:35:51.087Z]       |                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~​
[2022-11-03T13:35:51.087Z]       |                                            |​
[2022-11-03T13:35:51.087Z]       |                                            const png_uint_32 * {aka const unsigned int *}​
[2022-11-03T13:35:51.087Z] In file included from libpng/arm/palette_neon_intrinsics.c:20:​
[2022-11-03T13:35:51.087Z] prebuilts/gcc/linux/arm/lib/gcc/arm-none-eabi/10.3.1/include/arm_neon.h:10592:34: note: expected 'const uint32_t *' {aka 'const long unsigned int *'} but argument is of type 'const png_uint_32 *' {aka 'const unsigned int *'}​
[2022-11-03T13:35:51.087Z] 10592 | vld1q_lane_u32 (const uint32_t * __a, uint32x4_t __b, const int __c)​
[2022-11-03T13:35:51.087Z]       |                 ~~~~~~~~~~~~~~~~~^~~​
[2022-11-03T13:35:51.087Z] libpng/arm/palette_neon_intrinsics.c:89:44: warning: passing argument 1 of 'vld1q_lane_u32' from incompatible pointer type [-Wincompatible-pointer-types]​
[2022-11-03T13:35:51.087Z]    89 |       cur = vld1q_lane_u32(riffled_palette + *(sp - 0), cur, 3);​
[2022-11-03T13:35:51.087Z]       |                            ~~~~~~~~~~~~~~~~^~~~~~~~~~~​
[2022-11-03T13:35:51.087Z]       |                                            |​
[2022-11-03T13:35:51.087Z]       |                                            const png_uint_32 * {aka const unsigned int *}​
[2022-11-03T13:35:51.087Z] In file included from libpng/arm/palette_neon_intrinsics.c:20:​
[2022-11-03T13:35:51.087Z] prebuilts/gcc/linux/arm/lib/gcc/arm-none-eabi/10.3.1/include/arm_neon.h:10592:34: note: expected 'const uint32_t *' {aka 'const long unsigned int *'} but argument is of type 'const png_uint_32 *' {aka 'const unsigned int *'}​
[2022-11-03T13:35:51.087Z] 10592 | vld1q_lane_u32 (const uint32_t * __a, uint32x4_t __b, const int __c)​
[2022-11-03T13:35:51.087Z]       |                 ~~~~~~~~~~~~~~~~~^~~​

Signed-off-by: weizihan <weizihan@xiaomi.com>
Change-Id: I0cec44440c9d316598632cefd28902a75dfb0f47