### PR TITLE
chore: Fixed minor doc typo in `pnglibconf.dfa`

### DIFF
--- a/scripts/pnglibconf.dfa
+++ b/scripts/pnglibconf.dfa
@@ -69,7 +69,7 @@ file pnglibconf.h scripts/pnglibconf.dfa PNGLCONF_H
 #
 # 1) Create 'pngusr.h', enter the required private build information
 # detailed below and #define PNG_NO_<option> for each option you
-# don't want in that file in that file.  You can also turn on options
+# don't want in that file.  You can also turn on options
 # using PNG_<option>_SUPPORTED.  When you have finished rerun
 # configure and rebuild pnglibconf.h file with -DPNG_USER_CONFIG:
 #


### PR DESCRIPTION
Found this minor typo while configuring `pnglibconf.h`