### PR TITLE
configure: allow to disable building of tools and tests.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,13 +12,21 @@ PNGLIB_BASENAME= libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@
 ACLOCAL_AMFLAGS = -I scripts
 
 # test programs - run on make check, make distcheck
+if ENABLE_PNG_TESTS
 check_PROGRAMS= pngtest pngunknown pngstest pngvalid pngimage pngcp
 if HAVE_CLOCK_GETTIME
 check_PROGRAMS += timepng
 endif
+else
+check_PROGRAMS=
+endif
 
 # Utilities - installed
+if ENABLE_PNG_TOOLS
 bin_PROGRAMS= pngfix png-fix-itxt
+else
+bin_PROGRAMS=
+endif
 
 # This ensures that pnglibconf.h gets built at the start of 'make all' or
 # 'make check', but it does not add dependencies to the individual programs,
@@ -30,6 +38,7 @@ bin_PROGRAMS= pngfix png-fix-itxt
 # always wrong and always very confusing.
 BUILT_SOURCES = pnglibconf.h
 
+if ENABLE_PNG_TESTS
 pngtest_SOURCES = pngtest.c
 pngtest_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
@@ -48,16 +57,20 @@ pngimage_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 timepng_SOURCES = contrib/libtests/timepng.c
 timepng_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
+pngcp_SOURCES = contrib/tools/pngcp.c
+pngcp_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
+endif
+
+if ENABLE_PNG_TOOLS
 pngfix_SOURCES = contrib/tools/pngfix.c
 pngfix_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
 png_fix_itxt_SOURCES = contrib/tools/png-fix-itxt.c
-
-pngcp_SOURCES = contrib/tools/pngcp.c
-pngcp_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
+endif
 
 # Generally these are single line shell scripts to run a test with a particular
 # set of parameters:
+if ENABLE_PNG_TESTS
 TESTS =\
    tests/pngtest-all\
    tests/pngvalid-gamma-16-to-8 tests/pngvalid-gamma-alpha-mode\
@@ -75,6 +88,7 @@ TESTS =\
    tests/pngunknown-discard tests/pngunknown-if-safe tests/pngunknown-sAPI\
    tests/pngunknown-sTER tests/pngunknown-save tests/pngunknown-vpAg\
    tests/pngimage-quick tests/pngimage-full
+endif
 
 # man pages
 dist_man_MANS= libpng.3 libpngpf.3 png.5

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,22 @@ fi
 DFNCPP="$CPP"
 AC_SUBST(DFNCPP)
 
+AC_ARG_ENABLE([png-tests],
+   AS_HELP_STRING([--enable-png-tests],
+      [enable building of the test programs. This is done by default - use]
+      [--disable-png-tests to change this.]))
+
+AM_CONDITIONAL([ENABLE_PNG_TESTS],
+   [test "$enable_png_tests" != "no"])
+
+AC_ARG_ENABLE([png-tools],
+   AS_HELP_STRING([--enable-png-tools],
+      [enable building of the tool programs. This is done by default - use]
+      [--disable-png-tools to change this.]))
+
+AM_CONDITIONAL([ENABLE_PNG_TOOLS],
+   [test "$enable_png_tools" != "no"])
+
 # -Werror cannot be passed to GCC in CFLAGS because configure will fail
 # (it checks the compiler with a program that generates a warning).
 # Add the following option to deal with this:


### PR DESCRIPTION
This PR adds two set of options to the configure script:
`--enable-png-tests`/`--disable-png-tests`
and
`--enable-png-tools`/`--disable-png-tools`

By using this feature, an user will be allowed to build only library if needed, which will be useful on platforms not able to build the tools and/or the tests. This PR leaves the existing behaviour as default setting, by building both the tools and the tests if the options are not used.

Actually, CMakeLists.txt already supports this feature with options `PNG_TESTS` and `PNG_EXECUTABLES`.
After this commit, Autotools will provide the same feature.