### PR TITLE
pcal: avoid memory leak when allocation fails

### DIFF
--- a/pngset.c
+++ b/pngset.c
@@ -401,6 +401,7 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
 
    memset(info_ptr->pcal_params, 0, ((unsigned int)nparams + 1) *
        (sizeof (png_charp)));
+   info_ptr->free_me |= PNG_FREE_PCAL;
 
    for (i = 0; i < nparams; i++)
    {
@@ -421,7 +422,6 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
    }
 
    info_ptr->valid |= PNG_INFO_pCAL;
-   info_ptr->free_me |= PNG_FREE_PCAL;
 }
 #endif
 


### PR DESCRIPTION
Sets `PNG_FREE_PCAL` as soon as `pcal_params` is allocated so that even if one of `pcal_params[i]` allocation fails, the array `pcal_params` still gets freed by `png_free_data`

Found by nallocfuzz cf https://github.com/google/oss-fuzz/pull/9902