### PR TITLE
Fix bashisms

### DIFF
--- a/contrib/testpngs/makepngs.sh
+++ b/contrib/testpngs/makepngs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Make a set of test PNG files, MAKEPNG is the name of the makepng executable
 # built from contrib/libtests/makepng.c

--- a/contrib/tools/intgamma.sh
+++ b/contrib/tools/intgamma.sh
@@ -19,7 +19,7 @@
 
 # Function to print out a list of numbers as integers; the function truncates
 # the integers which must be one-per-line.
-function print(){
+print(){
    awk 'BEGIN{
       str = ""
    }


### PR DESCRIPTION
makepngs.sh relies on a Bash feature in one of its case statements, ";;&"; this should be made explicit in the shebang.

intgamma.sh declares a function in a manner which may fail in non-Bash sh implementations, this patch uses the correct syntax.

Based on a patch by Roflcopter4:
https://github.com/joncampbell123/dosbox-x/pull/3850