### PR TITLE
Fix copying targets on Windows in multi-config build systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,7 +929,7 @@ function(create_symlink DEST_FILE)
                          POST_BUILD
                          COMMAND "${CMAKE_COMMAND}"
                                  -E copy_if_different
-                                 $<TARGET_LINKER_FILE_NAME:${_SYM_TARGET}>
+                                 $<TARGET_LINKER_FILE_DIR:${_SYM_TARGET}>/$<TARGET_LINKER_FILE_NAME:${_SYM_TARGET}>
                                  $<TARGET_LINKER_FILE_DIR:${_SYM_TARGET}>/${DEST_FILE})
     else()
       add_custom_command(TARGET ${_SYM_TARGET}


### PR DESCRIPTION
Using a multi-config build system on Windows with CMake does not currently work, because the targets are located in a sub-directory. On other systems, it creates a symlink which works, because the link source is relative to the destination file. But copying must be done relative to the current directory.

So, this change fixes the issue by adding the folder name to the copy commands, which are only being run on Windows.