### PR TITLE
Don't report a valid tRNS chunk if it was canceled

### DIFF
--- a/pngget.c
+++ b/pngget.c
@@ -21,7 +21,18 @@ png_get_valid(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32 flag)
 {
    if (png_ptr != NULL && info_ptr != NULL)
+   {
+#ifdef PNG_READ_tRNS_SUPPORTED
+      /* png_handle_PLTE() may have canceled a valid tRNS chunk but left the
+       * 'valid' flag for the detection of duplicate chunks. Do not report a
+       * valid tRNS chunk in this case.
+       */
+      if (flag == PNG_INFO_tRNS && png_ptr->num_trans == 0)
+         return(0);
+#endif
+
       return(info_ptr->valid & flag);
+   }
 
    return(0);
 }


### PR DESCRIPTION
Add special handling of the PNG_INFO_tRNS flag to png_get_valid() to not report a canceled tRNS chunk as valid.

Fix https://github.com/glennrp/libpng/issues/482.