### PR TITLE
Fix CPU architecture match expressions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,9 +119,9 @@ endif()
 if(PNG_HARDWARE_OPTIMIZATIONS)
 
 # Set definitions and sources for ARM.
-if(TARGET_ARCH MATCHES "^arm" OR
+if(TARGET_ARCH MATCHES "^[aA][rR][mM]" OR
    TARGET_ARCH MATCHES "^aarch64")
-  if(TARGET_ARCH MATCHES "^arm64" OR
+  if(TARGET_ARCH MATCHES "^[aA][rR][mM]64" OR
      TARGET_ARCH MATCHES "^aarch64")
     set(PNG_ARM_NEON_POSSIBLE_VALUES on off)
     set(PNG_ARM_NEON "on"
@@ -153,8 +153,8 @@ if(TARGET_ARCH MATCHES "^arm" OR
 endif()
 
 # Set definitions and sources for PowerPC.
-if(TARGET_ARCH MATCHES "^powerpc*" OR
-   TARGET_ARCH MATCHES "^ppc64*")
+if(TARGET_ARCH MATCHES "^powerpc" OR
+   TARGET_ARCH MATCHES "^ppc64")
   set(PNG_POWERPC_VSX_POSSIBLE_VALUES on off)
   set(PNG_POWERPC_VSX "on"
       CACHE STRING "Enable POWERPC VSX optimizations: on|off; on is default")
@@ -176,8 +176,9 @@ if(TARGET_ARCH MATCHES "^powerpc*" OR
 endif()
 
 # Set definitions and sources for Intel.
-if(TARGET_ARCH MATCHES "^i?86" OR
-   TARGET_ARCH MATCHES "^x86_64*")
+if(TARGET_ARCH MATCHES "^i[3-6]86" OR
+   TARGET_ARCH MATCHES "^x86" OR
+   TARGET_ARCH MATCHES "^[aA][mM][dD]64")
   set(PNG_INTEL_SSE_POSSIBLE_VALUES on off)
   set(PNG_INTEL_SSE "on"
       CACHE STRING "Enable INTEL_SSE optimizations: on|off; on is default")
@@ -199,8 +200,8 @@ if(TARGET_ARCH MATCHES "^i?86" OR
 endif()
 
 # Set definitions and sources for MIPS.
-if(TARGET_ARCH MATCHES "mipsel*" OR
-   TARGET_ARCH MATCHES "mips64el*")
+if(TARGET_ARCH MATCHES "^mipsel" OR
+   TARGET_ARCH MATCHES "^mips64el")
   set(PNG_MIPS_MSA_POSSIBLE_VALUES on off)
   set(PNG_MIPS_MSA "on"
       CACHE STRING "Enable MIPS_MSA optimizations: on|off; on is default")
@@ -224,26 +225,27 @@ endif()
 else(PNG_HARDWARE_OPTIMIZATIONS)
 
 # Set definitions and sources for ARM.
-if(TARGET_ARCH MATCHES "^arm" OR
+if(TARGET_ARCH MATCHES "^[aA][rR][mM]" OR
    TARGET_ARCH MATCHES "^aarch64")
   add_definitions(-DPNG_ARM_NEON_OPT=0)
 endif()
 
 # Set definitions and sources for PowerPC.
-if(TARGET_ARCH MATCHES "^powerpc*" OR
-   TARGET_ARCH MATCHES "^ppc64*")
+if(TARGET_ARCH MATCHES "^powerpc" OR
+   TARGET_ARCH MATCHES "^ppc64")
   add_definitions(-DPNG_POWERPC_VSX_OPT=0)
 endif()
 
 # Set definitions and sources for Intel.
-if(TARGET_ARCH MATCHES "^i?86" OR
-   TARGET_ARCH MATCHES "^x86_64*")
+if(TARGET_ARCH MATCHES "^i[3-6]86" OR
+   TARGET_ARCH MATCHES "^x86" OR
+   TARGET_ARCH MATCHES "^[aA][mM][dD]64")
   add_definitions(-DPNG_INTEL_SSE_OPT=0)
 endif()
 
 # Set definitions and sources for MIPS.
-if(TARGET_ARCH MATCHES "mipsel*" OR
-   TARGET_ARCH MATCHES "mips64el*")
+if(TARGET_ARCH MATCHES "^mipsel" OR
+   TARGET_ARCH MATCHES "^mips64el")
   add_definitions(-DPNG_MIPS_MSA_OPT=0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,11 @@ if(TARGET_ARCH MATCHES "^[aA][rR][mM]" OR
   elseif(NOT ${PNG_ARM_NEON} STREQUAL "off")
     set(libpng_arm_sources
         arm/arm_init.c
-        arm/filter_neon.S
         arm/filter_neon_intrinsics.c
         arm/palette_neon_intrinsics.c)
+    if(NOT MSVC)
+      list(APPEND libpng_arm_sources arm/filter_neon.S)
+    endif()
     if(${PNG_ARM_NEON} STREQUAL "on")
       add_definitions(-DPNG_ARM_NEON_OPT=2)
     elseif(${PNG_ARM_NEON} STREQUAL "check")


### PR DESCRIPTION
The current expressions for CPU architecture matching use `?` and `*` as if they are wildcards, resulting in incorrect interpretation by CMake's regex matching.

At best, these are benign.  For example, `^powerpc*` will match `powerp` and `powerpcccccc`, which is likely not intended, but it will also match the intended `powerpc`.

More problematic is `^i?86`, which will match `i86` and `86`, but not the intended `i386` or `i686`.

Additionally, the expressions used do not match the architectures set by some toolchains, including `x86`, `AMD64`, and `ARM64`, which are used by MSVC.

This PR updates the expressions to match their intent and adds handling for the missed architectures, making the matches case-insensitive where appropriate.

With the Arm64 code now enabled for MSVC, the GAS assembly file must be excluded for MSVC.  `pngpriv.h` disables the Arm32 assembly code for all but GCC anyway.

Closes https://github.com/glennrp/libpng/issues/213