### PR TITLE
Add runtime zlib version number check for Apples

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -423,7 +423,8 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
 
 #if ZLIB_VERNUM >= 0x1290 && \
    defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32)
-      if (((png_ptr->options >> PNG_IGNORE_ADLER32) & 3) == PNG_OPTION_ON)
+      if (((png_ptr->options >> PNG_IGNORE_ADLER32) & 3) == PNG_OPTION_ON &&
+          inflateValidate != NULL)
          /* Turn off validation of the ADLER32 checksum in IDAT chunks */
          ret = inflateValidate(&png_ptr->zstream, 0);
 #endif


### PR DESCRIPTION
On Apple systems libpng may be compiled against a newer version of zlib than the library eventually gets used on.  This may or may not work but in the specific case of Issue 187 it apparently results in a crash (a test case has not yet been established).

This change modifies pngrutil.c to verify that the compiled version number of zlib matches the installed version number and applies that verification to the problem call.

This is minimalist but safe; as such it is, in fact, a good check for all calls (on all operating systems) to zlib which have version number checks. The Linux Foundation man page for 'zlibVersion' (at least in what I found) recommends, "Applications should compare the value returned from zlibVersion() with the macro constant ZLIB_VERSION for compatibility."

I don't have the faintest idea how up-to-date that is.

I recommend that this patch be reviewed by the various parties contributing to Issue 187 and that at least one of them confirm that an application which crashes (at the relevant point) without the patch no longer crashes with it.

TESTED: gentoo-dev, gcc (Gentoo 13.2.1_p20231216 p11) 13.2.1 20231216 with 'cmake, make all, make test' and 'configure, makedistcheck'.