### PR TITLE
png_safe_execute setjmp and GCC warning fixes

### DIFF
--- a/png.c
+++ b/png.c
@@ -732,6 +732,7 @@ png_convert_to_rfc1123_buffer(char out[29], png_const_timep ptime)
    {
       size_t pos = 0;
       char number_buf[5]; /* enough for a four-digit year */
+      /* INITIALIZED by PNG_FORMAT_NUMBER below: */
 
 #     define APPEND_STRING(string) pos = png_safecat(out, 29, pos, (string))
 #     define APPEND_NUMBER(format, value)\


### PR DESCRIPTION
png_safe_execute called setjmp in a context where the result is undefined (an assignment statement).  This corrects the code.

The GCC diagnostic -Wmaybe-uninitialized switches on warnings of possible problems in functions calling setjmp and in code which passes a pointer to an uninitialized object to a function taking a (const*) pointer.

At present png_safe_execute seems not to suffer from the later warnings even when the spurious (volatile auto) declarations are removed.  They have been removed (a likely performance benefit because spurious stack variables have been removed) and every auto/register variable in extent at the setjmp call has been marked (const), guaranteeing no modification in the function after or, indeed, before the setjmp call.

The known existing case where -Wmaybe-uninitialized causes spurious warnings is caused by the number formating support in png_format_number; it takes a (const) pointer to the start of the buffer which is never initialized; the buffer is accessed via the 'end' (non-const) pointer and 'start' is, effectively an end point.  (This is an unfortunate feature of Arabic numbers; in LtoR languages they are written backwards...)

The change disables the warning around the code in question with GCC specific pragmas, as used elsewhere for similar problems.

configure; make; make check now succeed with:

CFLAGS="-Wall -Werror" ../configure -enable-werror

and cmake builds pass make; make test.