### PR TITLE
write palette check corrections

### DIFF
--- a/pngwrite.c
+++ b/pngwrite.c
@@ -369,7 +369,8 @@ png_write_end(png_structrp png_ptr, png_inforp info_ptr)
       png_error(png_ptr, "No IDATs written into file");
 
 #ifdef PNG_WRITE_CHECK_FOR_INVALID_INDEX_SUPPORTED
-   if (png_ptr->num_palette_max > png_ptr->num_palette)
+   if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE &&
+       png_ptr->num_palette_max >= png_ptr->num_palette)
       png_benign_error(png_ptr, "Wrote palette index exceeding num_palette");
 #endif
 


### PR DESCRIPTION
The write palette check is off-by-one when checking the maximum palette index against the number of entries however, because of the implementation, the simple correction would fail if no palette check had been performed (for example for a non-palette image).  This corrects both errors so that the code outputs a warning (but not an error) if a user of libpng writes an image with a PLTE which is one entry short.

The write palette check can be turned off on colour type 3 images (colour mapping images) but this is done by setting the 'maximum' palette index in the image to (-1).  The ammended code works because it only executes for paletted images, it is dependent on palette checks being compiled in and they will always be checked unless the stored 'max' value is less than 0.