### PR TITLE
MIPS: Fixed undefined MSA interfaces

### DIFF
--- a/mips/mips_init.c
+++ b/mips/mips_init.c
@@ -21,7 +21,7 @@
 
 #ifdef PNG_READ_SUPPORTED
 
-#if PNG_MIPS_MSA_OPT > 0 || PNG_MIPS_MMI_IMPLEMENTATION > 0
+#if PNG_MIPS_MSA_IMPLEMENTATION == 1 || PNG_MIPS_MMI_IMPLEMENTATION > 0
 
 #ifdef PNG_MIPS_MSA_CHECK_SUPPORTED /* Do MIPS MSA run-time checks */
 /* WARNING: it is strongly recommended that you do not build libpng with
@@ -129,7 +129,7 @@ png_init_filter_functions_mips(png_structp pp, unsigned int bpp)
 #endif /* PNG_MIPS_MMI_IMPLEMENTATION > 0 */
 
 MIPS_MSA_INIT:
-#if PNG_MIPS_MSA_OPT > 0
+#if PNG_MIPS_MSA_IMPLEMENTATION == 1
    /* The switch statement is compiled in for MIPS_MSA_API, the call to
     * png_have_msa is compiled in for MIPS_MSA_CHECK. If both are defined
     * the check is only performed if the API has not set the MSA option on
@@ -197,8 +197,8 @@ MIPS_MSA_INIT:
       pp->read_filter[PNG_FILTER_VALUE_AVG-1] = png_read_filter_row_avg4_msa;
       pp->read_filter[PNG_FILTER_VALUE_PAETH-1] = png_read_filter_row_paeth4_msa;
    }
-#endif /* PNG_MIPS_MSA_OPT > 0 */
+#endif /* PNG_MIPS_MSA_IMPLEMENTATION == 1 */
    return;
 }
-#endif /* PNG_MIPS_MSA_OPT > 0 || PNG_MIPS_MMI_IMPLEMENTATION > 0 */
+#endif /* PNG_MIPS_MSA_IMPLEMENTATION == 1 || PNG_MIPS_MMI_IMPLEMENTATION > 0 */
 #endif /* READ */

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -258,7 +258,6 @@
 #endif
 
 #if PNG_MIPS_MSA_OPT > 0
-#  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_mips
 #  ifndef PNG_MIPS_MSA_IMPLEMENTATION
 #     if defined(__mips_msa)
 #        if defined(__clang__)
@@ -274,6 +273,7 @@
 
 #  ifndef PNG_MIPS_MSA_IMPLEMENTATION
 #     define PNG_MIPS_MSA_IMPLEMENTATION 1
+#     define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_mips
 #  endif
 #else
 #  define PNG_MIPS_MSA_IMPLEMENTATION 0
@@ -1338,7 +1338,7 @@ PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_neon,(png_row_infop
     row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
 #endif
 
-#if PNG_MIPS_MSA_OPT > 0
+#if PNG_MIPS_MSA_IMPLEMENTATION == 1
 PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_msa,(png_row_infop row_info,
     png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
 PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub3_msa,(png_row_infop
@@ -2160,7 +2160,7 @@ PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_neon,
    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
 #endif
 
-#if PNG_MIPS_MSA_OPT > 0
+#if PNG_MIPS_MSA_IMPLEMENTATION == 1
 PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_mips,
    (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
 #endif


### PR DESCRIPTION
When compiling on the MIPS platform using the following command: 
`./configure --enable-hardware-optimizations && make` 
The options `-mmsa -mfp64` are not being passed.
`PNG_MIPS_MSA_IMPLEMENTATION` is defined as 2, leading to the initialization of unimplemented MSA interfaces.
Error message：

> libtool: link: gcc -g -O2 -o .libs/pngfix contrib/tools/pngfix.o  ./.libs/libpng16.so -lz -lm
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_avg4_msa'
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_sub3_msa'
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_up_msa'
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_avg3_msa'
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_sub4_msa'
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_paeth3_msa'
> /usr/bin/ld: ./.libs/libpng16.so: undefined reference to `png_read_filter_row_paeth4_msa'
> collect2: error: ld returned 1 exit status